### PR TITLE
feat: dry-run, --no-mail, --validate, JSON schema & e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,5 +43,8 @@ jobs:
       - name: Install dependencies
         run: poetry install --no-interaction
 
-      - name: Run tests
-        run: poetry run pytest tests/ -v -W ignore::DeprecationWarning --tb=short
+      - name: Unit tests
+        run: poetry run pytest tests/ -v -W ignore::DeprecationWarning --tb=short --ignore=tests/test_e2e.py
+
+      - name: E2E tests
+        run: poetry run pytest tests/test_e2e.py -v -W ignore::DeprecationWarning --tb=short

--- a/config.schema.json
+++ b/config.schema.json
@@ -1,0 +1,173 @@
+{
+  "$defs": {
+    "MailConfig": {
+      "properties": {
+        "smtp_host": {
+          "title": "Smtp Host",
+          "type": "string"
+        },
+        "smtp_port": {
+          "default": 587,
+          "title": "Smtp Port",
+          "type": "integer"
+        },
+        "smtp_user": {
+          "title": "Smtp User",
+          "type": "string"
+        },
+        "smtp_password_keyvault_id": {
+          "title": "Smtp Password Keyvault Id",
+          "type": "string"
+        },
+        "smtp_password_secret_name": {
+          "title": "Smtp Password Secret Name",
+          "type": "string"
+        },
+        "from_address": {
+          "title": "From Address",
+          "type": "string"
+        },
+        "to_addresses": {
+          "items": {
+            "type": "string"
+          },
+          "title": "To Addresses",
+          "type": "array"
+        }
+      },
+      "required": [
+        "smtp_host",
+        "smtp_user",
+        "smtp_password_keyvault_id",
+        "smtp_password_secret_name",
+        "from_address",
+        "to_addresses"
+      ],
+      "title": "MailConfig",
+      "type": "object"
+    },
+    "MainConfig": {
+      "properties": {
+        "tenant_id": {
+          "title": "Tenant Id",
+          "type": "string"
+        },
+        "master_client_id": {
+          "title": "Master Client Id",
+          "type": "string"
+        },
+        "master_keyvault_id": {
+          "title": "Master Keyvault Id",
+          "type": "string"
+        },
+        "master_keyvault_secret_name": {
+          "title": "Master Keyvault Secret Name",
+          "type": "string"
+        },
+        "threshold_days": {
+          "default": 7,
+          "title": "Threshold Days",
+          "type": "integer"
+        },
+        "validity_days": {
+          "default": 365,
+          "title": "Validity Days",
+          "type": "integer"
+        },
+        "master_owners": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Master Owners",
+          "type": "array"
+        }
+      },
+      "required": [
+        "tenant_id",
+        "master_client_id",
+        "master_keyvault_id",
+        "master_keyvault_secret_name"
+      ],
+      "title": "MainConfig",
+      "type": "object"
+    },
+    "SecretConfig": {
+      "properties": {
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "app_id": {
+          "title": "App Id",
+          "type": "string"
+        },
+        "keyvault_id": {
+          "title": "Keyvault Id",
+          "type": "string"
+        },
+        "keyvault_secret_name": {
+          "title": "Keyvault Secret Name",
+          "type": "string"
+        },
+        "keyvault_secret_description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Keyvault Secret Description"
+        },
+        "required_owners": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Required Owners",
+          "type": "array"
+        }
+      },
+      "required": [
+        "name",
+        "app_id",
+        "keyvault_id",
+        "keyvault_secret_name"
+      ],
+      "title": "SecretConfig",
+      "type": "object"
+    }
+  },
+  "properties": {
+    "main": {
+      "$ref": "#/$defs/MainConfig"
+    },
+    "mail": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/MailConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "secrets": {
+      "items": {
+        "$ref": "#/$defs/SecretConfig"
+      },
+      "title": "Secrets",
+      "type": "array"
+    }
+  },
+  "required": [
+    "main",
+    "secrets"
+  ],
+  "title": "SRF Configuration",
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Schema for the SRF (Service Principal Secret Rotation Framework) input.yaml configuration file"
+}

--- a/main.py
+++ b/main.py
@@ -22,7 +22,8 @@ def _make_kv_factory(credential):
 
 def _print_summary(results: list[RotationResult]) -> None:
     rotated = [r for r in results if r.rotated]
-    skipped = [r for r in results if not r.rotated and r.error is None]
+    skipped = [r for r in results if not r.rotated and r.error is None and not r.dry_run]
+    dry_run_results = [r for r in results if r.dry_run]
     failed = [r for r in results if not r.rotated and r.error is not None]
 
     col = "{:<20} {:<38} {:<26} {:<26} {}"
@@ -50,6 +51,22 @@ def _print_summary(results: list[RotationResult]) -> None:
             _fmt(r.current_expiry),
             "not expiring soon",
         ))
+    for r in dry_run_results:
+        if r.rotation_needed or r.was_created:
+            label = "WOULD CREATE" if r.was_created else "WOULD ROTATE"
+            print(col.format(
+                r.name[:19], r.app_id,
+                f"~ {label}",
+                _fmt(r.current_expiry),
+                f"vault={r.keyvault_name}",
+            ))
+        else:
+            print(col.format(
+                r.name[:19], r.app_id,
+                "– NO CHANGE",
+                _fmt(r.current_expiry),
+                "not expiring soon (dry-run)",
+            ))
     for r in failed:
         print(col.format(
             r.name[:19], r.app_id,
@@ -84,7 +101,12 @@ def _print_ownership_summary(ownership_results: list[OwnershipResult]) -> None:
     for r in skipped:
         print(col.format(r.name[:19], r.app_id, "SKIPPED", "no required_owners configured"))
     for r in checked:
-        if r.error:
+        if r.dry_run:
+            if r.owners_would_add:
+                print(col.format(r.name[:19], r.app_id, "~ WOULD UPDATE", f"would_add={r.owners_would_add}"))
+            else:
+                print(col.format(r.name[:19], r.app_id, "– OK", "owners OK (dry-run)"))
+        elif r.error:
             print(col.format(r.name[:19], r.app_id, "✗ FAILED", (r.error or "")[:60]))
         elif r.owners_added:
             print(col.format(r.name[:19], r.app_id, "✓ UPDATED", f"added={r.owners_added}"))
@@ -114,7 +136,27 @@ def main() -> int:
     parser.add_argument("--workers", type=int, default=5, help="Max parallel workers (default: 5)")
     parser.add_argument("--threshold-days", type=int, default=None, help="Days before expiry to trigger rotation (default: 7)")
     parser.add_argument("--validity-days", type=int, default=None, help="Validity of new secrets in days (default: 365)")
+    parser.add_argument("--dry-run", action="store_true", help="Show what would change without making any writes")
+    parser.add_argument("--no-mail", action="store_true", help="Suppress email report even if mail config is present")
+    parser.add_argument("--validate", action="store_true", help="Validate input YAML against config.schema.json and exit")
     args = parser.parse_args()
+
+    if args.validate:
+        import json
+        import pathlib
+
+        import jsonschema
+        import yaml as _yaml
+        schema_path = pathlib.Path(__file__).parent / "config.schema.json"
+        schema = json.loads(schema_path.read_text())
+        raw = _yaml.safe_load(open(args.config))
+        try:
+            jsonschema.validate(instance=raw, schema=schema)
+            print("✅ Config is valid.")
+        except jsonschema.ValidationError as e:
+            print(f"❌ Validation error: {e.message}")
+            sys.exit(1)
+        sys.exit(0)
 
     config = load_config(args.config)
 
@@ -132,15 +174,16 @@ def main() -> int:
         keyvault_client_factory=kv_factory,
         threshold_days=threshold,
         validity_days=validity,
+        dry_run=args.dry_run,
     )
-    ownership_checker = OwnershipChecker(graph_client=graph, master_owners=config.main.master_owners)
+    ownership_checker = OwnershipChecker(graph_client=graph, master_owners=config.main.master_owners, dry_run=args.dry_run)
     runner = ParallelRunner(rotator=rotator, ownership_checker=ownership_checker, max_workers=args.workers)
     rotation_results, ownership_results = runner.run(config.secrets)
 
     _print_summary(rotation_results)
     _print_ownership_summary(ownership_results)
 
-    if config.mail:
+    if not args.no_mail and config.mail:
         print("\nSending email report...")
         reporter = MailReporter(
             mail_config=config.mail,

--- a/poetry.lock
+++ b/poetry.lock
@@ -907,6 +907,43 @@ files = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "4.26.0"
+description = "An implementation of JSON Schema validation for Python"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce"},
+    {file = "jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326"},
+]
+
+[package.dependencies]
+attrs = ">=22.2.0"
+jsonschema-specifications = ">=2023.3.6"
+referencing = ">=0.28.4"
+rpds-py = ">=0.25.0"
+
+[package.extras]
+format = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3987", "uri-template", "webcolors (>=1.11)"]
+format-nongpl = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3986-validator (>0.1.0)", "rfc3987-syntax (>=1.1.0)", "uri-template", "webcolors (>=24.6.0)"]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+description = "The JSON Schema meta-schemas and vocabularies, exposed as a Registry"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe"},
+    {file = "jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d"},
+]
+
+[package.dependencies]
+referencing = ">=0.31.0"
+
+[[package]]
 name = "microsoft-kiota-abstractions"
 version = "1.10.1"
 description = "Core abstractions for kiota generated libraries in Python"
@@ -1798,6 +1835,23 @@ files = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.37.0"
+description = "JSON Referencing + Python"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231"},
+    {file = "referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8"},
+]
+
+[package.dependencies]
+attrs = ">=22.2.0"
+rpds-py = ">=0.7.0"
+typing-extensions = {version = ">=4.4.0", markers = "python_version < \"3.13\""}
+
+[[package]]
 name = "requests"
 version = "2.33.1"
 description = "Python HTTP for Humans."
@@ -1818,6 +1872,131 @@ urllib3 = ">=1.26,<3"
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<8)"]
+
+[[package]]
+name = "rpds-py"
+version = "0.30.0"
+description = "Python bindings to Rust's persistent data structures (rpds)"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "rpds_py-0.30.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:679ae98e00c0e8d68a7fda324e16b90fd5260945b45d3b824c892cec9eea3288"},
+    {file = "rpds_py-0.30.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4cc2206b76b4f576934f0ed374b10d7ca5f457858b157ca52064bdfc26b9fc00"},
+    {file = "rpds_py-0.30.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:389a2d49eded1896c3d48b0136ead37c48e221b391c052fba3f4055c367f60a6"},
+    {file = "rpds_py-0.30.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:32c8528634e1bf7121f3de08fa85b138f4e0dc47657866630611b03967f041d7"},
+    {file = "rpds_py-0.30.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f207f69853edd6f6700b86efb84999651baf3789e78a466431df1331608e5324"},
+    {file = "rpds_py-0.30.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:67b02ec25ba7a9e8fa74c63b6ca44cf5707f2fbfadae3ee8e7494297d56aa9df"},
+    {file = "rpds_py-0.30.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c0e95f6819a19965ff420f65578bacb0b00f251fefe2c8b23347c37174271f3"},
+    {file = "rpds_py-0.30.0-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:a452763cc5198f2f98898eb98f7569649fe5da666c2dc6b5ddb10fde5a574221"},
+    {file = "rpds_py-0.30.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e0b65193a413ccc930671c55153a03ee57cecb49e6227204b04fae512eb657a7"},
+    {file = "rpds_py-0.30.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:858738e9c32147f78b3ac24dc0edb6610000e56dc0f700fd5f651d0a0f0eb9ff"},
+    {file = "rpds_py-0.30.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:da279aa314f00acbb803da1e76fa18666778e8a8f83484fba94526da5de2cba7"},
+    {file = "rpds_py-0.30.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:7c64d38fb49b6cdeda16ab49e35fe0da2e1e9b34bc38bd78386530f218b37139"},
+    {file = "rpds_py-0.30.0-cp310-cp310-win32.whl", hash = "sha256:6de2a32a1665b93233cde140ff8b3467bdb9e2af2b91079f0333a0974d12d464"},
+    {file = "rpds_py-0.30.0-cp310-cp310-win_amd64.whl", hash = "sha256:1726859cd0de969f88dc8673bdd954185b9104e05806be64bcd87badbe313169"},
+    {file = "rpds_py-0.30.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a2bffea6a4ca9f01b3f8e548302470306689684e61602aa3d141e34da06cf425"},
+    {file = "rpds_py-0.30.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dc4f992dfe1e2bc3ebc7444f6c7051b4bc13cd8e33e43511e8ffd13bf407010d"},
+    {file = "rpds_py-0.30.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:422c3cb9856d80b09d30d2eb255d0754b23e090034e1deb4083f8004bd0761e4"},
+    {file = "rpds_py-0.30.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:07ae8a593e1c3c6b82ca3292efbe73c30b61332fd612e05abee07c79359f292f"},
+    {file = "rpds_py-0.30.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:12f90dd7557b6bd57f40abe7747e81e0c0b119bef015ea7726e69fe550e394a4"},
+    {file = "rpds_py-0.30.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:99b47d6ad9a6da00bec6aabe5a6279ecd3c06a329d4aa4771034a21e335c3a97"},
+    {file = "rpds_py-0.30.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33f559f3104504506a44bb666b93a33f5d33133765b0c216a5bf2f1e1503af89"},
+    {file = "rpds_py-0.30.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:946fe926af6e44f3697abbc305ea168c2c31d3e3ef1058cf68f379bf0335a78d"},
+    {file = "rpds_py-0.30.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:495aeca4b93d465efde585977365187149e75383ad2684f81519f504f5c13038"},
+    {file = "rpds_py-0.30.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d9a0ca5da0386dee0655b4ccdf46119df60e0f10da268d04fe7cc87886872ba7"},
+    {file = "rpds_py-0.30.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8d6d1cc13664ec13c1b84241204ff3b12f9bb82464b8ad6e7a5d3486975c2eed"},
+    {file = "rpds_py-0.30.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3896fa1be39912cf0757753826bc8bdc8ca331a28a7c4ae46b7a21280b06bb85"},
+    {file = "rpds_py-0.30.0-cp311-cp311-win32.whl", hash = "sha256:55f66022632205940f1827effeff17c4fa7ae1953d2b74a8581baaefb7d16f8c"},
+    {file = "rpds_py-0.30.0-cp311-cp311-win_amd64.whl", hash = "sha256:a51033ff701fca756439d641c0ad09a41d9242fa69121c7d8769604a0a629825"},
+    {file = "rpds_py-0.30.0-cp311-cp311-win_arm64.whl", hash = "sha256:47b0ef6231c58f506ef0b74d44e330405caa8428e770fec25329ed2cb971a229"},
+    {file = "rpds_py-0.30.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a161f20d9a43006833cd7068375a94d035714d73a172b681d8881820600abfad"},
+    {file = "rpds_py-0.30.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6abc8880d9d036ecaafe709079969f56e876fcf107f7a8e9920ba6d5a3878d05"},
+    {file = "rpds_py-0.30.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca28829ae5f5d569bb62a79512c842a03a12576375d5ece7d2cadf8abe96ec28"},
+    {file = "rpds_py-0.30.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a1010ed9524c73b94d15919ca4d41d8780980e1765babf85f9a2f90d247153dd"},
+    {file = "rpds_py-0.30.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8d1736cfb49381ba528cd5baa46f82fdc65c06e843dab24dd70b63d09121b3f"},
+    {file = "rpds_py-0.30.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d948b135c4693daff7bc2dcfc4ec57237a29bd37e60c2fabf5aff2bbacf3e2f1"},
+    {file = "rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47f236970bccb2233267d89173d3ad2703cd36a0e2a6e92d0560d333871a3d23"},
+    {file = "rpds_py-0.30.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2e6ecb5a5bcacf59c3f912155044479af1d0b6681280048b338b28e364aca1f6"},
+    {file = "rpds_py-0.30.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a8fa71a2e078c527c3e9dc9fc5a98c9db40bcc8a92b4e8858e36d329f8684b51"},
+    {file = "rpds_py-0.30.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73c67f2db7bc334e518d097c6d1e6fed021bbc9b7d678d6cc433478365d1d5f5"},
+    {file = "rpds_py-0.30.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5ba103fb455be00f3b1c2076c9d4264bfcb037c976167a6047ed82f23153f02e"},
+    {file = "rpds_py-0.30.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7cee9c752c0364588353e627da8a7e808a66873672bcb5f52890c33fd965b394"},
+    {file = "rpds_py-0.30.0-cp312-cp312-win32.whl", hash = "sha256:1ab5b83dbcf55acc8b08fc62b796ef672c457b17dbd7820a11d6c52c06839bdf"},
+    {file = "rpds_py-0.30.0-cp312-cp312-win_amd64.whl", hash = "sha256:a090322ca841abd453d43456ac34db46e8b05fd9b3b4ac0c78bcde8b089f959b"},
+    {file = "rpds_py-0.30.0-cp312-cp312-win_arm64.whl", hash = "sha256:669b1805bd639dd2989b281be2cfd951c6121b65e729d9b843e9639ef1fd555e"},
+    {file = "rpds_py-0.30.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f83424d738204d9770830d35290ff3273fbb02b41f919870479fab14b9d303b2"},
+    {file = "rpds_py-0.30.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7536cd91353c5273434b4e003cbda89034d67e7710eab8761fd918ec6c69cf8"},
+    {file = "rpds_py-0.30.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2771c6c15973347f50fece41fc447c054b7ac2ae0502388ce3b6738cd366e3d4"},
+    {file = "rpds_py-0.30.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0a59119fc6e3f460315fe9d08149f8102aa322299deaa5cab5b40092345c2136"},
+    {file = "rpds_py-0.30.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:76fec018282b4ead0364022e3c54b60bf368b9d926877957a8624b58419169b7"},
+    {file = "rpds_py-0.30.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:692bef75a5525db97318e8cd061542b5a79812d711ea03dbc1f6f8dbb0c5f0d2"},
+    {file = "rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9027da1ce107104c50c81383cae773ef5c24d296dd11c99e2629dbd7967a20c6"},
+    {file = "rpds_py-0.30.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:9cf69cdda1f5968a30a359aba2f7f9aa648a9ce4b580d6826437f2b291cfc86e"},
+    {file = "rpds_py-0.30.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a4796a717bf12b9da9d3ad002519a86063dcac8988b030e405704ef7d74d2d9d"},
+    {file = "rpds_py-0.30.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5d4c2aa7c50ad4728a094ebd5eb46c452e9cb7edbfdb18f9e1221f597a73e1e7"},
+    {file = "rpds_py-0.30.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba81a9203d07805435eb06f536d95a266c21e5b2dfbf6517748ca40c98d19e31"},
+    {file = "rpds_py-0.30.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:945dccface01af02675628334f7cf49c2af4c1c904748efc5cf7bbdf0b579f95"},
+    {file = "rpds_py-0.30.0-cp313-cp313-win32.whl", hash = "sha256:b40fb160a2db369a194cb27943582b38f79fc4887291417685f3ad693c5a1d5d"},
+    {file = "rpds_py-0.30.0-cp313-cp313-win_amd64.whl", hash = "sha256:806f36b1b605e2d6a72716f321f20036b9489d29c51c91f4dd29a3e3afb73b15"},
+    {file = "rpds_py-0.30.0-cp313-cp313-win_arm64.whl", hash = "sha256:d96c2086587c7c30d44f31f42eae4eac89b60dabbac18c7669be3700f13c3ce1"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:eb0b93f2e5c2189ee831ee43f156ed34e2a89a78a66b98cadad955972548be5a"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:922e10f31f303c7c920da8981051ff6d8c1a56207dbdf330d9047f6d30b70e5e"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cdc62c8286ba9bf7f47befdcea13ea0e26bf294bda99758fd90535cbaf408000"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:47f9a91efc418b54fb8190a6b4aa7813a23fb79c51f4bb84e418f5476c38b8db"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f3587eb9b17f3789ad50824084fa6f81921bbf9a795826570bda82cb3ed91f2"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:39c02563fc592411c2c61d26b6c5fe1e51eaa44a75aa2c8735ca88b0d9599daa"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51a1234d8febafdfd33a42d97da7a43f5dcb120c1060e352a3fbc0c6d36e2083"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:eb2c4071ab598733724c08221091e8d80e89064cd472819285a9ab0f24bcedb9"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6bdfdb946967d816e6adf9a3d8201bfad269c67efe6cefd7093ef959683c8de0"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c77afbd5f5250bf27bf516c7c4a016813eb2d3e116139aed0096940c5982da94"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:61046904275472a76c8c90c9ccee9013d70a6d0f73eecefd38c1ae7c39045a08"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-win32.whl", hash = "sha256:3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d"},
+    {file = "rpds_py-0.30.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0"},
+    {file = "rpds_py-0.30.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be"},
+    {file = "rpds_py-0.30.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f"},
+    {file = "rpds_py-0.30.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f"},
+    {file = "rpds_py-0.30.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87"},
+    {file = "rpds_py-0.30.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18"},
+    {file = "rpds_py-0.30.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad"},
+    {file = "rpds_py-0.30.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07"},
+    {file = "rpds_py-0.30.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f"},
+    {file = "rpds_py-0.30.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65"},
+    {file = "rpds_py-0.30.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f"},
+    {file = "rpds_py-0.30.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53"},
+    {file = "rpds_py-0.30.0-cp314-cp314-win32.whl", hash = "sha256:ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed"},
+    {file = "rpds_py-0.30.0-cp314-cp314-win_amd64.whl", hash = "sha256:95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950"},
+    {file = "rpds_py-0.30.0-cp314-cp314-win_arm64.whl", hash = "sha256:613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3"},
+    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c2262bdba0ad4fc6fb5545660673925c2d2a5d9e2e0fb603aad545427be0fc58"},
+    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:ee6af14263f25eedc3bb918a3c04245106a42dfd4f5c2285ea6f997b1fc3f89a"},
+    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3adbb8179ce342d235c31ab8ec511e66c73faa27a47e076ccc92421add53e2bb"},
+    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:250fa00e9543ac9b97ac258bd37367ff5256666122c2d0f2bc97577c60a1818c"},
+    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9854cf4f488b3d57b9aaeb105f06d78e5529d3145b1e4a41750167e8c213c6d3"},
+    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:993914b8e560023bc0a8bf742c5f303551992dcb85e247b1e5c7f4a7d145bda5"},
+    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58edca431fb9b29950807e301826586e5bbf24163677732429770a697ffe6738"},
+    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:dea5b552272a944763b34394d04577cf0f9bd013207bc32323b5a89a53cf9c2f"},
+    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ba3af48635eb83d03f6c9735dfb21785303e73d22ad03d489e88adae6eab8877"},
+    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a"},
+    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4"},
+    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e"},
+    {file = "rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84"},
+]
 
 [[package]]
 name = "std-uritemplate"
@@ -2042,4 +2221,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "6d1fedbaed05cd188dbc6cf3ceb27180cc86913add927961a513574f188e9cd8"
+content-hash = "1f28f5a15ad91cdc5c74350e4b06d1658d8cc7fa8ccbe06c60bc3b13e2bdec20"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,8 @@ dependencies = [
     "azure-keyvault-secrets (>=4.9.0)",
     "msgraph-sdk (>=1.5.0)",
     "pydantic (>=2.10.0)",
-    "pyyaml (>=6.0.2)"
+    "pyyaml (>=6.0.2)",
+    "jsonschema (>=4.0.0)"
 ]
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ azure-keyvault-secrets>=4.9.0
 msgraph-sdk>=1.5.0
 pydantic>=2.10.0
 pyyaml>=6.0.2
+jsonschema>=4.0.0

--- a/srf/config/models.py
+++ b/srf/config/models.py
@@ -41,6 +41,11 @@ class AppConfig(BaseModel):
     secrets: list[SecretConfig]
 
 
+def generate_schema() -> dict:
+    """Return the JSON Schema for AppConfig (useful for YAML validation and IDE support)."""
+    return AppConfig.model_json_schema()
+
+
 def load_config(path: str) -> AppConfig:
     with open(path, "r", encoding="utf-8") as fh:
         raw = yaml.safe_load(fh)

--- a/srf/ownership/checker.py
+++ b/srf/ownership/checker.py
@@ -15,12 +15,15 @@ class OwnershipResult:
     owners_added: list[str] = field(default_factory=list)
     owners_already_present: list[str] = field(default_factory=list)
     error: Optional[str] = field(default=None)
+    owners_would_add: list[str] = field(default_factory=list)
+    dry_run: bool = field(default=False)
 
 
 class OwnershipChecker:
-    def __init__(self, graph_client: GraphClient, master_owners: list[str] | None = None) -> None:
+    def __init__(self, graph_client: GraphClient, master_owners: list[str] | None = None, dry_run: bool = False) -> None:
         self._graph = graph_client
         self._master_owners = master_owners or []
+        self._dry_run = dry_run
 
     def check_and_update(self, secret_config: SecretConfig) -> OwnershipResult:
         seen = set()
@@ -36,14 +39,23 @@ class OwnershipChecker:
         try:
             current_owners = self._graph.list_owners(secret_config.app_id)
             current_set = set(current_owners)
-            already_present = []
+            already_present = [uid for uid in effective_owners if uid in current_set]
+            missing = [uid for uid in effective_owners if uid not in current_set]
+
+            if self._dry_run:
+                return OwnershipResult(
+                    name=secret_config.name,
+                    app_id=secret_config.app_id,
+                    checked=True,
+                    dry_run=True,
+                    owners_already_present=already_present,
+                    owners_would_add=missing,
+                )
+
             added = []
-            for user_id in effective_owners:
-                if user_id in current_set:
-                    already_present.append(user_id)
-                else:
-                    self._graph.add_owner(secret_config.app_id, user_id)
-                    added.append(user_id)
+            for user_id in missing:
+                self._graph.add_owner(secret_config.app_id, user_id)
+                added.append(user_id)
             return OwnershipResult(
                 name=secret_config.name,
                 app_id=secret_config.app_id,

--- a/srf/rotation/rotator.py
+++ b/srf/rotation/rotator.py
@@ -20,6 +20,9 @@ class RotationResult:
     new_expiry: Optional[datetime] = field(default=None)
     current_expiry: Optional[datetime] = field(default=None)
     keyvault_name: Optional[str] = field(default=None)
+    was_created: bool = field(default=False)
+    dry_run: bool = field(default=False)
+    rotation_needed: bool = field(default=False)
 
 
 def _vault_name_from_id(keyvault_id: str) -> str:
@@ -35,6 +38,7 @@ class SecretRotator:
         keyvault_client_factory,
         threshold_days: int = 7,
         validity_days: int = 365,
+        dry_run: bool = False,
     ) -> None:
         """
         Args:
@@ -43,11 +47,13 @@ class SecretRotator:
                 returns a ready KeyVaultClient. Allows per-SP vaults.
             threshold_days: Rotate if expiry is within this many days (or already expired).
             validity_days: Validity period for newly created credentials.
+            dry_run: If True, no writes are made; results reflect what would happen.
         """
         self._graph = graph_client
         self._kv_factory = keyvault_client_factory
         self._threshold = timedelta(days=threshold_days)
         self._validity_days = validity_days
+        self._dry_run = dry_run
 
     # ------------------------------------------------------------------
 
@@ -78,13 +84,36 @@ class SecretRotator:
         vault_name = _vault_name_from_id(secret_config.keyvault_id)
         try:
             credentials = self._graph.list_password_credentials(secret_config.app_id)
+            was_created = len(credentials) == 0
             should_rotate, current_expiry = self.needs_rotation(credentials)
 
             if not should_rotate:
+                if self._dry_run:
+                    return RotationResult(
+                        name=secret_config.name,
+                        app_id=secret_config.app_id,
+                        rotated=False,
+                        dry_run=True,
+                        rotation_needed=False,
+                        current_expiry=current_expiry,
+                        keyvault_name=vault_name,
+                    )
                 return RotationResult(
                     name=secret_config.name,
                     app_id=secret_config.app_id,
                     rotated=False,
+                    current_expiry=current_expiry,
+                    keyvault_name=vault_name,
+                )
+
+            if self._dry_run:
+                return RotationResult(
+                    name=secret_config.name,
+                    app_id=secret_config.app_id,
+                    rotated=False,
+                    dry_run=True,
+                    rotation_needed=True,
+                    was_created=was_created,
                     current_expiry=current_expiry,
                     keyvault_name=vault_name,
                 )
@@ -119,6 +148,7 @@ class SecretRotator:
                 new_expiry=new_cred.end_date_time,
                 current_expiry=current_expiry,
                 keyvault_name=vault_name,
+                was_created=was_created,
             )
 
         except Exception as exc:

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,0 +1,217 @@
+"""End-to-end tests for CLI flags --validate, --dry-run, and --no-mail.
+
+All Azure SDK calls are monkeypatched; no subprocess, no real network traffic.
+"""
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+
+import main  # root-level main.py
+
+# ---------------------------------------------------------------------------
+# YAML content helpers
+# ---------------------------------------------------------------------------
+
+_BASE_YAML = """\
+main:
+  tenant_id: "tenant-abc"
+  master_client_id: "master-app-id"
+  master_keyvault_id: "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.KeyVault/vaults/myvault"
+  master_keyvault_secret_name: "master-secret"
+  threshold_days: 7
+  validity_days: 365
+secrets:
+  - name: "sp-test"
+    app_id: "app-id-123"
+    keyvault_id: "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.KeyVault/vaults/myvault"
+    keyvault_secret_name: "sp-test-secret"
+"""
+
+# mail block using exact Pydantic field names from MailConfig
+_MAIL_BLOCK = """\
+mail:
+  smtp_host: "smtp.example.com"
+  smtp_port: 587
+  smtp_user: "user@example.com"
+  smtp_password_keyvault_id: "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.KeyVault/vaults/myvault"
+  smtp_password_secret_name: "mail-pw"
+  from_address: "a@b.com"
+  to_addresses:
+    - "c@d.com"
+"""
+
+_INVALID_YAML = """\
+main:
+  tenant_x: "bad"
+  master_client_id: "master-app-id"
+  master_keyvault_id: "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.KeyVault/vaults/myvault"
+  master_keyvault_secret_name: "master-secret"
+secrets:
+  - name: "sp-test"
+    app_id: "app-id-123"
+    keyvault_id: "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.KeyVault/vaults/myvault"
+    keyvault_secret_name: "sp-test-secret"
+"""
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def minimal_yaml(tmp_path):
+    p = tmp_path / "config.yaml"
+    p.write_text(_BASE_YAML)
+    return p
+
+
+@pytest.fixture
+def yaml_with_mail(tmp_path):
+    p = tmp_path / "config_mail.yaml"
+    p.write_text(_BASE_YAML + _MAIL_BLOCK)
+    return p
+
+
+@pytest.fixture
+def mock_azure(monkeypatch):
+    """Patch every Azure SDK touch-point so tests never make real network calls.
+
+    Returns a dict of tracked MagicMock objects for assertions:
+      - "add_password_credential"
+      - "set_secret"
+      - "send_report"
+    """
+    # Credential expiring in 2 days — within the 7-day threshold, so rotation is needed.
+    mock_cred = MagicMock()
+    mock_cred.end_date_time = datetime.now(tz=timezone.utc) + timedelta(days=2)
+    mock_cred.key_id = "old-key-id"
+
+    mock_new_cred = MagicMock()
+    mock_new_cred.secret_text = "new-secret"
+    mock_new_cred.end_date_time = datetime.now(tz=timezone.utc) + timedelta(days=365)
+    mock_new_cred.key_id = "new-key-id"
+
+    add_password = MagicMock(return_value=mock_new_cred)
+    set_secret = MagicMock(return_value=None)
+    send_report = MagicMock(return_value=None)
+
+    monkeypatch.setattr(
+        "srf.auth.provider.AuthProvider.get_master_credential",
+        lambda self: MagicMock(),
+    )
+    monkeypatch.setattr(
+        "srf.graph.client.GraphClient.__init__",
+        lambda self, *a, **kw: None,
+    )
+    monkeypatch.setattr(
+        "srf.graph.client.GraphClient.list_password_credentials",
+        lambda self, app_id: [mock_cred],
+    )
+    monkeypatch.setattr("srf.graph.client.GraphClient.add_password_credential", add_password)
+    monkeypatch.setattr(
+        "srf.graph.client.GraphClient.remove_password_credential",
+        lambda self, *a, **kw: None,
+    )
+    monkeypatch.setattr(
+        "srf.graph.client.GraphClient.list_owners",
+        lambda self, app_id: [],
+    )
+    monkeypatch.setattr(
+        "srf.graph.client.GraphClient.add_owner",
+        lambda self, *a, **kw: None,
+    )
+    monkeypatch.setattr(
+        "srf.keyvault.client.KeyVaultClient.__init__",
+        lambda self, *a, **kw: None,
+    )
+    monkeypatch.setattr(
+        "srf.keyvault.client.KeyVaultClient.get_secret",
+        lambda self, *a, **kw: "master-secret-value",
+    )
+    monkeypatch.setattr("srf.keyvault.client.KeyVaultClient.set_secret", set_secret)
+    monkeypatch.setattr("srf.reporting.mail.MailReporter.send_report", send_report)
+
+    return {
+        "add_password_credential": add_password,
+        "set_secret": set_secret,
+        "send_report": send_report,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests — --validate flag
+# ---------------------------------------------------------------------------
+
+def test_validate_valid_config(tmp_path, monkeypatch, capsys):
+    p = tmp_path / "valid.yaml"
+    p.write_text(_BASE_YAML)
+    monkeypatch.setattr(sys, "argv", ["srf", "--config", str(p), "--validate"])
+    with pytest.raises(SystemExit) as exc:
+        main.main()
+    assert exc.value.code == 0
+    assert "✅" in capsys.readouterr().out
+
+
+def test_validate_invalid_config(tmp_path, monkeypatch, capsys):
+    p = tmp_path / "invalid.yaml"
+    p.write_text(_INVALID_YAML)
+    monkeypatch.setattr(sys, "argv", ["srf", "--config", str(p), "--validate"])
+    with pytest.raises(SystemExit) as exc:
+        main.main()
+    assert exc.value.code == 1
+    assert "❌" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# Tests — --dry-run flag
+# ---------------------------------------------------------------------------
+
+def test_dry_run_no_writes(minimal_yaml, mock_azure, monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["srf", "--config", str(minimal_yaml), "--dry-run"])
+    main.main()
+    assert not mock_azure["add_password_credential"].called
+    assert not mock_azure["set_secret"].called
+    out = capsys.readouterr().out
+    assert "WOULD ROTATE" in out or "WOULD CREATE" in out
+
+
+def test_dry_run_output_contains_summary(minimal_yaml, mock_azure, monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["srf", "--config", str(minimal_yaml), "--dry-run"])
+    main.main()
+    out = capsys.readouterr().out
+    assert "~ WOULD" in out or "NO CHANGE" in out
+
+
+# ---------------------------------------------------------------------------
+# Tests — --no-mail flag
+# ---------------------------------------------------------------------------
+
+def test_no_mail_suppresses_send(yaml_with_mail, mock_azure, monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["srf", "--config", str(yaml_with_mail), "--no-mail"])
+    main.main()
+    assert not mock_azure["send_report"].called
+
+
+def test_mail_sent_without_no_mail(yaml_with_mail, mock_azure, monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["srf", "--config", str(yaml_with_mail)])
+    main.main()
+    mock_azure["send_report"].assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Tests — combined flags
+# ---------------------------------------------------------------------------
+
+def test_dry_run_and_no_mail_combined(yaml_with_mail, mock_azure, monkeypatch):
+    monkeypatch.setattr(
+        sys, "argv",
+        ["srf", "--config", str(yaml_with_mail), "--dry-run", "--no-mail"],
+    )
+    main.main()
+    assert not mock_azure["add_password_credential"].called
+    assert not mock_azure["set_secret"].called
+    assert not mock_azure["send_report"].called

--- a/tests/test_ownership.py
+++ b/tests/test_ownership.py
@@ -128,3 +128,33 @@ def test_skip_when_both_empty():
 
     assert result.checked is False
     graph.add_owner.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# dry-run
+# ---------------------------------------------------------------------------
+
+def test_dry_run_does_not_call_add_owner():
+    graph = MagicMock(spec=GraphClient)
+    graph.list_owners.return_value = ["u1"]
+    checker = OwnershipChecker(graph_client=graph, dry_run=True)
+
+    result = checker.check_and_update(_cfg(required_owners=["u1", "u2"]))
+
+    assert result.checked is True
+    assert result.dry_run is True
+    assert "u2" in result.owners_would_add
+    graph.add_owner.assert_not_called()
+
+
+def test_dry_run_all_present():
+    graph = MagicMock(spec=GraphClient)
+    graph.list_owners.return_value = ["u1", "u2"]
+    checker = OwnershipChecker(graph_client=graph, dry_run=True)
+
+    result = checker.check_and_update(_cfg(required_owners=["u1", "u2"]))
+
+    assert result.checked is True
+    assert result.dry_run is True
+    assert result.owners_would_add == []
+    graph.add_owner.assert_not_called()

--- a/tests/test_rotator.py
+++ b/tests/test_rotator.py
@@ -184,3 +184,90 @@ def test_rotate_returns_error_result_on_kv_failure():
 
     assert result.rotated is False
     assert "KV write failed" in result.error
+
+
+# ---------------------------------------------------------------------------
+# dry-run
+# ---------------------------------------------------------------------------
+
+def _make_dry_rotator(graph, kv):
+    return SecretRotator(
+        graph_client=graph,
+        keyvault_client_factory=lambda _: kv,
+        dry_run=True,
+    )
+
+
+def test_dry_run_skips_writes_when_rotation_needed():
+    graph = MagicMock()
+    graph.list_password_credentials.return_value = [_cred(-1)]  # expired
+
+    kv = MagicMock()
+    rotator = _make_dry_rotator(graph, kv)
+    result = rotator.rotate(_make_secret_cfg())
+
+    assert result.rotated is False
+    assert result.dry_run is True
+    assert result.rotation_needed is True
+    graph.add_password_credential.assert_not_called()
+    kv.set_secret.assert_not_called()
+
+
+def test_dry_run_skips_when_not_expiring():
+    graph = MagicMock()
+    graph.list_password_credentials.return_value = [_cred(30)]
+
+    rotator = _make_dry_rotator(graph, MagicMock())
+    result = rotator.rotate(_make_secret_cfg())
+
+    assert result.rotated is False
+    assert result.dry_run is True
+    assert result.rotation_needed is False
+
+
+def test_was_created_true_when_no_prior_credentials():
+    new_cred = MagicMock()
+    new_cred.key_id = "key-new"
+    new_cred.secret_text = "s"
+    new_cred.end_date_time = NOW + timedelta(days=365)
+
+    graph = MagicMock()
+    graph.list_password_credentials.return_value = []
+    graph.add_password_credential.return_value = new_cred
+
+    rotator = _make_rotator(graph, MagicMock())
+    result = rotator.rotate(_make_secret_cfg())
+
+    assert result.rotated is True
+    assert result.was_created is True
+
+
+def test_was_created_false_when_credentials_exist():
+    new_cred = MagicMock()
+    new_cred.key_id = "key-new"
+    new_cred.secret_text = "s"
+    new_cred.end_date_time = NOW + timedelta(days=365)
+
+    graph = MagicMock()
+    graph.list_password_credentials.return_value = [_cred(-1)]
+    graph.add_password_credential.return_value = new_cred
+
+    rotator = _make_rotator(graph, MagicMock())
+    result = rotator.rotate(_make_secret_cfg())
+
+    assert result.rotated is True
+    assert result.was_created is False
+
+
+def test_dry_run_was_created_true_no_prior_creds():
+    graph = MagicMock()
+    graph.list_password_credentials.return_value = []
+
+    kv = MagicMock()
+    rotator = _make_dry_rotator(graph, kv)
+    result = rotator.rotate(_make_secret_cfg())
+
+    assert result.dry_run is True
+    assert result.was_created is True
+    graph.add_password_credential.assert_not_called()
+    kv.set_secret.assert_not_called()


### PR DESCRIPTION
## Summary

This PR delivers 4 new features + end-to-end tests:

### New CLI flags
| Flag | Behaviour |
|------|-----------|
| `--dry-run` | Shows all estimated changes (WOULD ROTATE / WOULD CREATE / WOULD ADD) without writing anything to Azure or KeyVault |
| `--no-mail` | Suppresses the email report even when `mail:` is configured in YAML |
| `--validate` | Validates `input.yaml` against `config.schema.json` using jsonschema, prints ✅/❌ and exits |

### New result fields
- `RotationResult.rotation_needed` — distinguishes "would rotate" from "no action needed" in dry-run
- `RotationResult.was_created` — True when SP had no prior credentials (first-time setup)
- `OwnershipResult.owners_would_add` — dry-run list of owners that would be added
- `OwnershipResult.dry_run` — flag on result

### config.schema.json
- Pydantic-generated JSON Schema for `AppConfig`; committed to repo root for IDE support and `--validate`

### Tests
- 7 new end-to-end tests in `tests/test_e2e.py` covering all 3 new flags
- CI workflow split into **Unit tests** and **E2E tests** steps
- **70/70 tests passing** (63 unit + 7 e2e)

### Dependencies
- Added `jsonschema>=4.0.0`