### PR TITLE
fix: sanitize exception messages — prevent secret exposure in logs

### DIFF
--- a/srf/ownership/checker.py
+++ b/srf/ownership/checker.py
@@ -68,5 +68,5 @@ class OwnershipChecker:
                 name=secret_config.name,
                 app_id=secret_config.app_id,
                 checked=True,
-                error=str(exc),
+                error=f"{type(exc).__name__}: ownership check failed — check Azure logs for details",
             )

--- a/srf/rotation/rotator.py
+++ b/srf/rotation/rotator.py
@@ -152,10 +152,13 @@ class SecretRotator:
             )
 
         except Exception as exc:
+            # Use only the exception type — never str(exc) for operations that
+            # handle secrets. Azure SDK exceptions can embed request bodies,
+            # tokens, or the new secret value in their message text.
             return RotationResult(
                 name=secret_config.name,
                 app_id=secret_config.app_id,
                 rotated=False,
-                error=str(exc),
+                error=f"{type(exc).__name__}: rotation failed — check Azure logs for details",
                 keyvault_name=vault_name,
             )

--- a/srf/runner/parallel.py
+++ b/srf/runner/parallel.py
@@ -43,7 +43,7 @@ class ParallelRunner:
                                 name=secret.name,
                                 app_id=secret.app_id,
                                 rotated=False,
-                                error=f"Unexpected runner error: {exc}",
+                                error=f"{type(exc).__name__}: unexpected runner error",
                             )
                         )
                 else:
@@ -56,7 +56,7 @@ class ParallelRunner:
                                 name=secret.name,
                                 app_id=secret.app_id,
                                 checked=True,
-                                error=f"Unexpected runner error: {exc}",
+                                error=f"{type(exc).__name__}: unexpected runner error",
                             )
                         )
 

--- a/tests/test_ownership.py
+++ b/tests/test_ownership.py
@@ -79,7 +79,7 @@ def test_error_returns_error_result():
 
     assert result.checked is True
     assert result.error is not None
-    assert "graph down" in result.error
+    assert "RuntimeError" in result.error
 
 
 def test_master_owners_applied_to_all():

--- a/tests/test_rotator.py
+++ b/tests/test_rotator.py
@@ -163,7 +163,8 @@ def test_rotate_returns_error_result_on_graph_failure():
     result = rotator.rotate(_make_secret_cfg())
 
     assert result.rotated is False
-    assert "Graph API down" in result.error
+    assert result.error is not None
+    assert "RuntimeError" in result.error
 
 
 def test_rotate_returns_error_result_on_kv_failure():
@@ -183,7 +184,8 @@ def test_rotate_returns_error_result_on_kv_failure():
     result = rotator.rotate(_make_secret_cfg())
 
     assert result.rotated is False
-    assert "KV write failed" in result.error
+    assert result.error is not None
+    assert "RuntimeError" in result.error
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -65,7 +65,7 @@ def test_runner_continues_after_one_failure():
     failed = [r for r in rotation_results if r.name == "sp2"]
     assert len(failed) == 1
     assert failed[0].rotated is False
-    assert "Unexpected crash" in (failed[0].error or "")
+    assert "RuntimeError" in (failed[0].error or "")
 
 
 def test_runner_respects_max_workers(monkeypatch):


### PR DESCRIPTION
Azure SDK exceptions can embed request bodies or newly-generated secret values in their message. `str(exc)` in error fields risks leaking secrets to stdout and email.`n`nReplaces `str(exc)` with `type(exc).__name__` in rotator, checker, and runner. Tests updated.