### PR TITLE
fix: SMTP timeout and email error handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -185,12 +185,15 @@ def main() -> int:
 
     if not args.no_mail and config.mail:
         print("\nSending email report...")
-        reporter = MailReporter(
-            mail_config=config.mail,
-            keyvault_client_factory=kv_factory,
-        )
-        reporter.send_report(rotation_results)
-        print("Email sent.")
+        try:
+            reporter = MailReporter(
+                mail_config=config.mail,
+                keyvault_client_factory=kv_factory,
+            )
+            reporter.send_report(rotation_results)
+            print("Email sent.")
+        except Exception as exc:
+            print(f"WARNING: email report failed ({type(exc).__name__}) — rotation results above are complete.")
 
     failed_count = sum(1 for r in rotation_results if r.error)
     return 1 if failed_count > 0 else 0

--- a/srf/reporting/mail.py
+++ b/srf/reporting/mail.py
@@ -170,7 +170,7 @@ class MailReporter:
         msg.attach(MIMEText(html, "html"))
 
         password = self._fetch_smtp_password()
-        with smtplib.SMTP(self._cfg.smtp_host, self._cfg.smtp_port) as server:
+        with smtplib.SMTP(self._cfg.smtp_host, self._cfg.smtp_port, timeout=30) as server:
             server.ehlo()
             server.starttls()
             server.login(self._cfg.smtp_user, password)

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -87,7 +87,7 @@ def test_send_report_sends_to_all_recipients(monkeypatch):
     sent = {}
 
     class FakeSMTP:
-        def __init__(self, host, port): pass
+        def __init__(self, host, port, timeout=None): pass
         def __enter__(self): return self
         def __exit__(self, *a): pass
         def ehlo(self): pass
@@ -110,7 +110,7 @@ def test_send_report_fetches_smtp_password_from_kv(monkeypatch):
     reporter, kv = _make_reporter()
 
     class FakeSMTP:
-        def __init__(self, h, p): pass
+        def __init__(self, h, p, timeout=None): pass
         def __enter__(self): return self
         def __exit__(self, *a): pass
         def ehlo(self): pass


### PR DESCRIPTION
## Summary

- Added 	imeout=30 to smtplib.SMTP() (prevents indefinite hang on network issues)
- Wrapped send_report() call in main.py with 	ry/except — email failure prints a WARNING but does not affect the exit code or hide rotation results
- Updated FakeSMTP stubs in 	est_mail.py to accept the 	imeout kwarg

Fixes: medium-severity issues from code review (SMTP timeout + email crash prevention)