### PR TITLE
fix: include ownership failures in exit code

### DIFF
--- a/main.py
+++ b/main.py
@@ -193,7 +193,8 @@ def main() -> int:
         print("Email sent.")
 
     failed_count = sum(1 for r in rotation_results if r.error)
-    return 1 if failed_count > 0 else 0
+    ownership_failed_count = sum(1 for r in ownership_results if r.error)
+    return 1 if (failed_count + ownership_failed_count) > 0 else 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Ownership check failures are now counted toward the exit code. Previously xit 0 was returned even when owner enforcement had failed, which would hide errors in CI pipelines.

Fixes low-severity issue from code review.