### PR TITLE
fix: treat credentials with no expiry date as needing rotation

### DIFF
--- a/srf/rotation/rotator.py
+++ b/srf/rotation/rotator.py
@@ -68,7 +68,9 @@ class SecretRotator:
         for cred in credentials:
             expiry = cred.end_date_time
             if expiry is None:
-                continue
+                # A credential with no expiry is treated as requiring rotation:
+                # it cannot be tracked and may have been created without TTL controls.
+                return True, None
             if expiry.tzinfo is None:
                 expiry = expiry.replace(tzinfo=timezone.utc)
             if soonest is None or expiry < soonest:

--- a/tests/test_rotator.py
+++ b/tests/test_rotator.py
@@ -67,6 +67,16 @@ def test_needs_rotation_empty_returns_true():
     assert expiry is None
 
 
+def test_needs_rotation_none_expiry_returns_true():
+    """A credential with no expiry date should trigger rotation."""
+    rotator = _make_rotator(MagicMock(), MagicMock())
+    cred = MagicMock()
+    cred.end_date_time = None
+    result, expiry = rotator.needs_rotation([cred])
+    assert result is True
+    assert expiry is None
+
+
 def test_needs_rotation_returns_soonest_expiry():
     rotator = _make_rotator(MagicMock(), MagicMock())
     creds = [_cred(20), _cred(10), _cred(30)]


### PR DESCRIPTION
## Summary

When nd_date_time is None, the credential is now treated as requiring rotation instead of being silently skipped. Secrets without an expiry date cannot be tracked and likely represent legacy credentials created without TTL controls.

Added 	est_needs_rotation_none_expiry_returns_true to cover the new path.

Fixes low-severity issue from code review.