### PR TITLE
fix: cache appId->objectId in GraphClient to avoid redundant Graph API calls

### DIFF
--- a/srf/graph/client.py
+++ b/srf/graph/client.py
@@ -23,6 +23,7 @@ class GraphClient:
 
     def __init__(self, credential: TokenCredential) -> None:
         self._graph = GraphServiceClient(credential, scopes=_GRAPH_SCOPES)
+        self._object_id_cache: dict[str, str] = {}
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -33,7 +34,10 @@ class GraphClient:
         return asyncio.run(coro)
 
     async def _get_object_id(self, app_id: str) -> str:
-        """Resolve appId (client ID) to the application's object ID."""
+        """Resolve appId (client ID) to the application's object ID (cached)."""
+        if app_id in self._object_id_cache:
+            return self._object_id_cache[app_id]
+
         from msgraph.generated.applications.applications_request_builder import (
             ApplicationsRequestBuilder,
         )
@@ -48,7 +52,9 @@ class GraphClient:
         apps = result.value if result and result.value else []
         if not apps:
             raise ValueError(f"Application with appId '{app_id}' not found in the directory.")
-        return apps[0].id  # type: ignore[return-value]
+        obj_id: str = apps[0].id  # type: ignore[assignment]
+        self._object_id_cache[app_id] = obj_id
+        return obj_id
 
     # ------------------------------------------------------------------
     # Public API

--- a/tests/test_graph_client.py
+++ b/tests/test_graph_client.py
@@ -173,3 +173,23 @@ def test_add_owner_calls_ref_post():
     body = ref_post_mock.call_args[0][0]
     assert isinstance(body, ReferenceCreate)
     assert body.odata_id == f"https://graph.microsoft.com/v1.0/directoryObjects/{user_oid}"
+
+
+# ---------------------------------------------------------------------------
+# objectId cache
+# ---------------------------------------------------------------------------
+
+def test_object_id_cached_after_first_call():
+    """Second call for the same app_id must not hit the Graph API again."""
+    with patch("srf.graph.client.GraphServiceClient") as MockGraph:
+        instance = MockGraph.return_value
+        app = _make_app()
+        instance.applications.get = AsyncMock(return_value=_make_apps_list([app]))
+        instance.applications.by_application_id.return_value.get = AsyncMock(return_value=app)
+
+        client = GraphClient(credential=MagicMock())
+        client.list_password_credentials(APP_ID)
+        client.list_password_credentials(APP_ID)
+
+    # _get_object_id resolves via applications.get — it should only be called once
+    assert instance.applications.get.call_count == 1


### PR DESCRIPTION
## Summary

Each public method on GraphClient previously called _get_object_id() independently — triggering a new HTTP request for every operation on the same pp_id. A single rotation run can call list_password_credentials, dd_password_credential, and emove_password_credential for the same SP, causing 3 redundant ID lookups.

self._object_id_cache: dict[str, str] is populated on first lookup; subsequent calls use the cached value.

Added 	est_object_id_cached_after_first_call to verify the Graph API is hit only once per unique pp_id.

Fixes low-severity issue from code review.