### PR TITLE
fix: surface old-credential cleanup failures as warnings

### DIFF
--- a/main.py
+++ b/main.py
@@ -44,6 +44,8 @@ def _print_summary(results: list[RotationResult]) -> None:
             _fmt(r.new_expiry),
             f"vault={r.keyvault_name}",
         ))
+        for warning in r.cleanup_warnings:
+            print(f"  ⚠ CLEANUP WARNING: {warning}")
     for r in skipped:
         print(col.format(
             r.name[:19], r.app_id,

--- a/srf/rotation/rotator.py
+++ b/srf/rotation/rotator.py
@@ -23,6 +23,7 @@ class RotationResult:
     was_created: bool = field(default=False)
     dry_run: bool = field(default=False)
     rotation_needed: bool = field(default=False)
+    cleanup_warnings: list[str] = field(default_factory=list)
 
 
 def _vault_name_from_id(keyvault_id: str) -> str:
@@ -131,6 +132,7 @@ class SecretRotator:
                 description=secret_config.keyvault_secret_description,
             )
 
+            cleanup_warnings: list[str] = []
             for old_cred in credentials:
                 if old_cred.key_id and old_cred.key_id != new_cred.key_id:
                     try:
@@ -138,8 +140,11 @@ class SecretRotator:
                             app_id=secret_config.app_id,
                             key_id=str(old_cred.key_id),
                         )
-                    except Exception:
-                        pass  # best-effort cleanup of old credentials
+                    except Exception as exc:
+                        cleanup_warnings.append(
+                            f"Failed to remove old credential {old_cred.key_id}: "
+                            f"{type(exc).__name__}"
+                        )
 
             return RotationResult(
                 name=secret_config.name,
@@ -149,6 +154,7 @@ class SecretRotator:
                 current_expiry=current_expiry,
                 keyvault_name=vault_name,
                 was_created=was_created,
+                cleanup_warnings=cleanup_warnings,
             )
 
         except Exception as exc:

--- a/tests/test_rotator.py
+++ b/tests/test_rotator.py
@@ -186,9 +186,29 @@ def test_rotate_returns_error_result_on_kv_failure():
     assert "KV write failed" in result.error
 
 
-# ---------------------------------------------------------------------------
-# dry-run
-# ---------------------------------------------------------------------------
+def test_rotate_cleanup_failure_recorded_as_warning():
+    """If old credential removal fails, it should be in cleanup_warnings, not error."""
+    new_cred = MagicMock()
+    new_cred.key_id = "k-new"
+    new_cred.secret_text = "v"
+    new_cred.end_date_time = NOW + timedelta(days=365)
+
+    old_cred = _cred(-5)
+    old_cred.key_id = "k-old"
+
+    graph = MagicMock()
+    graph.list_password_credentials.return_value = [old_cred]
+    graph.add_password_credential.return_value = new_cred
+    graph.remove_password_credential.side_effect = RuntimeError("Graph error")
+
+    rotator = _make_rotator(graph, MagicMock())
+    result = rotator.rotate(_make_secret_cfg())
+
+    assert result.rotated is True
+    assert result.error is None
+    assert len(result.cleanup_warnings) == 1
+    assert "k-old" in result.cleanup_warnings[0]
+    assert "RuntimeError" in result.cleanup_warnings[0]
 
 def _make_dry_rotator(graph, kv):
     return SecretRotator(


### PR DESCRIPTION
## Summary

Previously emove_password_credential() failures were silently swallowed with xcept Exception: pass. Unremediated old credentials remain valid after rotation and represent a security risk.

**Changes:**
- cleanup_warnings: list[str] field added to RotationResult`n- Cleanup loop appends {type(exc).__name__}: failed to remove {key_id} messages on failure
- _print_summary() in main.py prints ⚠ CLEANUP WARNING: for each affected SP
- New test: 	est_rotate_cleanup_failure_recorded_as_warning`n
Rotation result is still otated=True when cleanup partially fails (the new secret was written to KV successfully).

Fixes medium-severity issue from code review.