### PR TITLE
feat: update OIDC workflow to use secrets and add master owners

### DIFF
--- a/.github/workflows/srf-run-oidc.yml
+++ b/.github/workflows/srf-run-oidc.yml
@@ -40,6 +40,7 @@ jobs:
   rotate:
     name: Rotate SP secrets
     runs-on: ubuntu-latest
+    environment: NonProd
 
     steps:
       - name: Checkout
@@ -48,8 +49,8 @@ jobs:
       - name: Azure login (OIDC)
         uses: azure/login@v2
         with:
-          client-id: ${{ vars.AZURE_CLIENT_ID }}
-          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           allow-no-subscriptions: true   # SRF uses Graph API + KV, not ARM subscriptions
 
       - name: Set up Python

--- a/input.yaml
+++ b/input.yaml
@@ -15,8 +15,9 @@ main:
   # master_keyvault_secret_name: master-sp-client-secret
   threshold_days: 7
   validity_days: 365
-  # master_owners:
-  #   - 00000000-0000-0000-0000-000000000099   # user object ID added to every SP
+  master_owners: # user object ID added to every SP
+    - 1338bb98-3041-4ef6-840d-45454bf9945f
+    - 4a0773b4-bddf-47e2-b1fd-8c847f9a6319   
 
 # Optional: omit this block entirely to skip email reporting
 mail:


### PR DESCRIPTION
## Summary

- Update OIDC workflow to use GitHub Secrets for SP credentials
- Add `master_owners` configuration to `input.yaml`

## Changes
- `.github/workflows/srf-run-oidc.yml`: updated workflow configuration
- `input.yaml`: added master owners section