### PR TITLE
feat: add per-secret threshold_days and validity_days overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,8 +279,33 @@ python main.py --workers 10
 | `--threshold-days` | YAML value (7) | Override: days before expiry to trigger rotation |
 | `--validity-days` | YAML value (365) | Override: new secret validity in days |
 | `--workers` | `5` | Max parallel threads |
+| `--dry-run` | off | Show what would change without making any writes |
+| `--no-mail` | off | Suppress email report even if mail config is present |
+| `--validate` | off | Validate `input.yaml` against the JSON schema and exit |
+| `--debug` | off | Enable `DEBUG` logging for SRF modules (overrides `LOG_LEVEL`) |
 
 > CLI flags always take precedence over YAML values when explicitly provided.
+
+### Logging
+
+By default the tool is silent (log level `WARNING`). To enable logs set the `LOG_LEVEL` environment variable or use the `--debug` flag:
+
+```bash
+# INFO — key milestones (auth mode, config loaded, rotation decisions)
+export LOG_LEVEL=INFO
+poetry run python main.py
+
+# DEBUG — full trace (Graph API calls, KV operations, ownership checks)
+export LOG_LEVEL=DEBUG
+poetry run python main.py
+
+# --debug flag — always DEBUG, takes priority over LOG_LEVEL
+poetry run python main.py --debug
+```
+
+Valid values for `LOG_LEVEL`: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`.
+
+> **Security:** only `srf.*` loggers are elevated. Third-party loggers (`azure`, `msgraph`, `urllib3`) always stay at `WARNING` to prevent tokens or request bodies from appearing in output.
 
 ---
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -97,8 +97,11 @@
         },
         "validity_days": {
           "default": 365,
-          "maximum": 730,
-          "minimum": 1,
+          "enum": [
+            90,
+            180,
+            365
+          ],
           "title": "Validity Days",
           "type": "integer"
         },
@@ -170,8 +173,11 @@
         "validity_days": {
           "anyOf": [
             {
-              "maximum": 730,
-              "minimum": 1,
+              "enum": [
+                90,
+                180,
+                365
+              ],
               "type": "integer"
             },
             {

--- a/config.schema.json
+++ b/config.schema.json
@@ -90,11 +90,15 @@
         },
         "threshold_days": {
           "default": 7,
+          "maximum": 365,
+          "minimum": 0,
           "title": "Threshold Days",
           "type": "integer"
         },
         "validity_days": {
           "default": 365,
+          "maximum": 730,
+          "minimum": 1,
           "title": "Validity Days",
           "type": "integer"
         },
@@ -148,6 +152,34 @@
           },
           "title": "Required Owners",
           "type": "array"
+        },
+        "threshold_days": {
+          "anyOf": [
+            {
+              "maximum": 365,
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Threshold Days"
+        },
+        "validity_days": {
+          "anyOf": [
+            {
+              "maximum": 730,
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Validity Days"
         }
       },
       "required": [

--- a/input.yaml
+++ b/input.yaml
@@ -7,7 +7,7 @@ main:
 
   # --- Auth Mode 2: GitHub Secret env var ---
   # Set SRF_MASTER_CLIENT_SECRET in your workflow env + uncomment:
-  # master_client_id: 422e63ed-df23-4bd0-98de-2a20762a7c7d
+  master_client_id: 422e63ed-df23-4bd0-98de-2a20762a7c7d
 
   # --- Auth Mode 3: Key Vault bootstrap (managed identity only, NOT for GitHub Actions) ---
   # master_client_id: 422e63ed-df23-4bd0-98de-2a20762a7c7d

--- a/input.yaml
+++ b/input.yaml
@@ -37,8 +37,8 @@ secrets:
     keyvault_id: /subscriptions/6801b1ff-7314-4480-8e4b-42f910440eb8/resourceGroups/slave1/providers/Microsoft.KeyVault/vaults/kv-slave1
     keyvault_secret_name: slave1-client-secret
     keyvault_secret_description: "Client secret for slave1 SP — managed by SRF rotation tool"
-    # threshold_days: 30   # override global threshold for this SP only
-    # validity_days: 180   # override global validity for this SP only
+    threshold_days: 0   # override global threshold for this SP only
+    validity_days: 180   # override global validity for this SP only
 
   - name: slave2
     app_id: 32e99f34-5731-4fa9-95ae-8115360b0701

--- a/input.yaml
+++ b/input.yaml
@@ -37,6 +37,8 @@ secrets:
     keyvault_id: /subscriptions/6801b1ff-7314-4480-8e4b-42f910440eb8/resourceGroups/slave1/providers/Microsoft.KeyVault/vaults/kv-slave1
     keyvault_secret_name: slave1-client-secret
     keyvault_secret_description: "Client secret for slave1 SP — managed by SRF rotation tool"
+    # threshold_days: 30   # override global threshold for this SP only
+    # validity_days: 180   # override global validity for this SP only
 
   - name: slave2
     app_id: 32e99f34-5731-4fa9-95ae-8115360b0701

--- a/main.py
+++ b/main.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import argparse
+import logging
+import os
 import sys
 from datetime import datetime, timezone
 
@@ -12,6 +14,8 @@ from srf.ownership.checker import OwnershipChecker, OwnershipResult
 from srf.reporting.mail import MailReporter
 from srf.rotation.rotator import RotationResult, SecretRotator
 from srf.runner.parallel import ParallelRunner
+
+logger = logging.getLogger(__name__)
 
 
 def _make_kv_factory(credential):
@@ -141,7 +145,29 @@ def main() -> int:
     parser.add_argument("--dry-run", action="store_true", help="Show what would change without making any writes")
     parser.add_argument("--no-mail", action="store_true", help="Suppress email report even if mail config is present")
     parser.add_argument("--validate", action="store_true", help="Validate input YAML against config.schema.json and exit")
+    parser.add_argument("--debug", action="store_true", help="Enable debug logging for SRF modules (overrides SRF_LOG_LEVEL)")
     args = parser.parse_args()
+
+    # Logging level priority: --debug flag > SRF_LOG_LEVEL env var > WARNING default.
+    # Only srf.* loggers are elevated — third-party loggers (azure, msgraph, kiota,
+    # urllib3) stay at WARNING to prevent leaking tokens or request bodies.
+    _ENV_LOG_LEVEL = "LOG_LEVEL"
+    _VALID_LEVELS = {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}
+    if args.debug:
+        log_level = logging.DEBUG
+    else:
+        env_level = os.environ.get(_ENV_LOG_LEVEL, "").upper()
+        if env_level and env_level not in _VALID_LEVELS:
+            print(f"WARNING: invalid {_ENV_LOG_LEVEL}={env_level!r}, expected one of {sorted(_VALID_LEVELS)}. Defaulting to WARNING.", file=sys.stderr)
+            env_level = ""
+        log_level = getattr(logging, env_level) if env_level else logging.WARNING
+    logging.basicConfig(
+        level=logging.WARNING,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        force=True,
+    )
+    logging.getLogger("srf").setLevel(log_level)
+    logging.getLogger(__name__).setLevel(log_level)
 
     if args.validate:
         import json
@@ -161,12 +187,14 @@ def main() -> int:
         sys.exit(0)
 
     config = load_config(args.config)
+    logger.info("Config loaded from %s — %d SP(s) configured", args.config, len(config.secrets))
 
     threshold = args.threshold_days if args.threshold_days is not None else config.main.threshold_days
     validity = args.validity_days if args.validity_days is not None else config.main.validity_days
 
     auth = AuthProvider(config.main)
     master_credential = auth.get_master_credential()
+    logger.info("Starting rotation run: dry_run=%s, threshold_days=%s, validity_days=%s", args.dry_run, threshold, validity)
 
     graph = GraphClient(credential=master_credential)
     kv_factory = _make_kv_factory(master_credential)

--- a/poetry.lock
+++ b/poetry.lock
@@ -604,6 +604,46 @@ test = ["certifi (>=2024)", "cryptography-vectors (==46.0.7)", "pretend (>=0.7)"
 test-randomorder = ["pytest-randomly"]
 
 [[package]]
+name = "debugpy"
+version = "1.8.20"
+description = "An implementation of the Debug Adapter Protocol for Python"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "debugpy-1.8.20-cp310-cp310-macosx_15_0_x86_64.whl", hash = "sha256:157e96ffb7f80b3ad36d808646198c90acb46fdcfd8bb1999838f0b6f2b59c64"},
+    {file = "debugpy-1.8.20-cp310-cp310-manylinux_2_34_x86_64.whl", hash = "sha256:c1178ae571aff42e61801a38b007af504ec8e05fde1c5c12e5a7efef21009642"},
+    {file = "debugpy-1.8.20-cp310-cp310-win32.whl", hash = "sha256:c29dd9d656c0fbd77906a6e6a82ae4881514aa3294b94c903ff99303e789b4a2"},
+    {file = "debugpy-1.8.20-cp310-cp310-win_amd64.whl", hash = "sha256:3ca85463f63b5dd0aa7aaa933d97cbc47c174896dcae8431695872969f981893"},
+    {file = "debugpy-1.8.20-cp311-cp311-macosx_15_0_universal2.whl", hash = "sha256:eada6042ad88fa1571b74bd5402ee8b86eded7a8f7b827849761700aff171f1b"},
+    {file = "debugpy-1.8.20-cp311-cp311-manylinux_2_34_x86_64.whl", hash = "sha256:7de0b7dfeedc504421032afba845ae2a7bcc32ddfb07dae2c3ca5442f821c344"},
+    {file = "debugpy-1.8.20-cp311-cp311-win32.whl", hash = "sha256:773e839380cf459caf73cc533ea45ec2737a5cc184cf1b3b796cd4fd98504fec"},
+    {file = "debugpy-1.8.20-cp311-cp311-win_amd64.whl", hash = "sha256:1f7650546e0eded1902d0f6af28f787fa1f1dbdbc97ddabaf1cd963a405930cb"},
+    {file = "debugpy-1.8.20-cp312-cp312-macosx_15_0_universal2.whl", hash = "sha256:4ae3135e2089905a916909ef31922b2d733d756f66d87345b3e5e52b7a55f13d"},
+    {file = "debugpy-1.8.20-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:88f47850a4284b88bd2bfee1f26132147d5d504e4e86c22485dfa44b97e19b4b"},
+    {file = "debugpy-1.8.20-cp312-cp312-win32.whl", hash = "sha256:4057ac68f892064e5f98209ab582abfee3b543fb55d2e87610ddc133a954d390"},
+    {file = "debugpy-1.8.20-cp312-cp312-win_amd64.whl", hash = "sha256:a1a8f851e7cf171330679ef6997e9c579ef6dd33c9098458bd9986a0f4ca52e3"},
+    {file = "debugpy-1.8.20-cp313-cp313-macosx_15_0_universal2.whl", hash = "sha256:5dff4bb27027821fdfcc9e8f87309a28988231165147c31730128b1c983e282a"},
+    {file = "debugpy-1.8.20-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:84562982dd7cf5ebebfdea667ca20a064e096099997b175fe204e86817f64eaf"},
+    {file = "debugpy-1.8.20-cp313-cp313-win32.whl", hash = "sha256:da11dea6447b2cadbf8ce2bec59ecea87cc18d2c574980f643f2d2dfe4862393"},
+    {file = "debugpy-1.8.20-cp313-cp313-win_amd64.whl", hash = "sha256:eb506e45943cab2efb7c6eafdd65b842f3ae779f020c82221f55aca9de135ed7"},
+    {file = "debugpy-1.8.20-cp314-cp314-macosx_15_0_universal2.whl", hash = "sha256:9c74df62fc064cd5e5eaca1353a3ef5a5d50da5eb8058fcef63106f7bebe6173"},
+    {file = "debugpy-1.8.20-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:077a7447589ee9bc1ff0cdf443566d0ecf540ac8aa7333b775ebcb8ce9f4ecad"},
+    {file = "debugpy-1.8.20-cp314-cp314-win32.whl", hash = "sha256:352036a99dd35053b37b7803f748efc456076f929c6a895556932eaf2d23b07f"},
+    {file = "debugpy-1.8.20-cp314-cp314-win_amd64.whl", hash = "sha256:a98eec61135465b062846112e5ecf2eebb855305acc1dfbae43b72903b8ab5be"},
+    {file = "debugpy-1.8.20-cp38-cp38-macosx_15_0_x86_64.whl", hash = "sha256:b773eb026a043e4d9c76265742bc846f2f347da7e27edf7fe97716ea19d6bfc5"},
+    {file = "debugpy-1.8.20-cp38-cp38-manylinux_2_34_x86_64.whl", hash = "sha256:20d6e64ea177ab6732bffd3ce8fc6fb8879c60484ce14c3b3fe183b1761459ca"},
+    {file = "debugpy-1.8.20-cp38-cp38-win32.whl", hash = "sha256:0dfd9adb4b3c7005e9c33df430bcdd4e4ebba70be533e0066e3a34d210041b66"},
+    {file = "debugpy-1.8.20-cp38-cp38-win_amd64.whl", hash = "sha256:60f89411a6c6afb89f18e72e9091c3dfbcfe3edc1066b2043a1f80a3bbb3e11f"},
+    {file = "debugpy-1.8.20-cp39-cp39-macosx_15_0_x86_64.whl", hash = "sha256:bff8990f040dacb4c314864da95f7168c5a58a30a66e0eea0fb85e2586a92cd6"},
+    {file = "debugpy-1.8.20-cp39-cp39-manylinux_2_34_x86_64.whl", hash = "sha256:70ad9ae09b98ac307b82c16c151d27ee9d68ae007a2e7843ba621b5ce65333b5"},
+    {file = "debugpy-1.8.20-cp39-cp39-win32.whl", hash = "sha256:9eeed9f953f9a23850c85d440bf51e3c56ed5d25f8560eeb29add815bd32f7ee"},
+    {file = "debugpy-1.8.20-cp39-cp39-win_amd64.whl", hash = "sha256:760813b4fff517c75bfe7923033c107104e76acfef7bda011ffea8736e9a66f8"},
+    {file = "debugpy-1.8.20-py2.py3-none-any.whl", hash = "sha256:5be9bed9ae3be00665a06acaa48f8329d2b9632f15fd09f6a9a8c8d9907e54d7"},
+    {file = "debugpy-1.8.20.tar.gz", hash = "sha256:55bc8701714969f1ab89a6d5f2f3d40c36f91b2cbe2f65d98bf8196f6a6a2c33"},
+]
+
+[[package]]
 name = "frozenlist"
 version = "1.8.0"
 description = "A list-like structure which implements collections.abc.MutableSequence"
@@ -2221,4 +2261,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "1f28f5a15ad91cdc5c74350e4b06d1658d8cc7fa8ccbe06c60bc3b13e2bdec20"
+content-hash = "bec8e18a0d4badb912765fbfd2c1a64b4fcf95a60687628e02f395fb7a921c71"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,4 +20,4 @@ requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [dependency-groups]
-dev = ["pytest (>=8.3.0)", "pytest-mock (>=3.14.0)"]
+dev = ["pytest (>=8.3.0)", "pytest-mock (>=3.14.0)", "debugpy (>=1.8.0)"]

--- a/srf/auth/provider.py
+++ b/srf/auth/provider.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 
 from azure.core.credentials import TokenCredential
@@ -9,6 +10,7 @@ from srf.config.models import MainConfig
 from srf.keyvault.client import KeyVaultClient
 
 _ENV_VAR = "SRF_MASTER_CLIENT_SECRET"
+logger = logging.getLogger(__name__)
 
 
 class AuthProvider:
@@ -49,6 +51,7 @@ class AuthProvider:
                 raise RuntimeError(
                     f"{_ENV_VAR!r} is set but 'master_client_id' is missing from the YAML config."
                 )
+            logger.info("Auth mode 1: ClientSecretCredential via %s env var (client_id=%s)", _ENV_VAR, self._config.master_client_id)
             return ClientSecretCredential(
                 tenant_id=self._config.tenant_id,
                 client_id=self._config.master_client_id,
@@ -63,6 +66,7 @@ class AuthProvider:
                 raise RuntimeError(
                     "Key Vault bootstrap requires 'master_client_id' in the YAML config."
                 )
+            logger.info("Auth mode 3: Key Vault bootstrap (keyvault=%s, client_id=%s)", self._config.master_keyvault_id, self._config.master_client_id)
             bootstrap_credential = DefaultAzureCredential()
             kv = KeyVaultClient(
                 credential=bootstrap_credential,
@@ -83,5 +87,6 @@ class AuthProvider:
         #   - Local: az login session
         #   - Azure compute: Managed Identity
         # No client secret is required; Azure handles token exchange.
+        logger.info("Auth mode 2: DefaultAzureCredential (OIDC / az login / Managed Identity)")
         return DefaultAzureCredential()
 

--- a/srf/config/models.py
+++ b/srf/config/models.py
@@ -42,6 +42,18 @@ class SecretConfig(BaseModel):
     keyvault_secret_name: str
     keyvault_secret_description: Optional[str] = Field(default=None)
     required_owners: list[str] = Field(default_factory=list)
+    threshold_days: Optional[int] = Field(default=None, ge=0, le=365)
+    validity_days: Optional[int] = Field(default=None, ge=1, le=730)
+
+    @model_validator(mode="after")
+    def _validity_exceeds_threshold(self) -> "SecretConfig":
+        if self.validity_days is not None and self.threshold_days is not None:
+            if self.validity_days <= self.threshold_days:
+                raise ValueError(
+                    f"validity_days ({self.validity_days}) must be greater than "
+                    f"threshold_days ({self.threshold_days})"
+                )
+        return self
 
 
 class AppConfig(BaseModel):

--- a/srf/config/models.py
+++ b/srf/config/models.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
-from typing import Optional
+from typing import Literal, Optional
 
 import yaml
 from pydantic import BaseModel, Field, model_validator
+
+ValidityDays = Literal[90, 180, 365]
 
 
 class MainConfig(BaseModel):
@@ -12,7 +14,7 @@ class MainConfig(BaseModel):
     master_keyvault_id: Optional[str] = Field(default=None)
     master_keyvault_secret_name: Optional[str] = Field(default=None)
     threshold_days: int = Field(default=7, ge=0, le=365)
-    validity_days: int = Field(default=365, ge=1, le=730)
+    validity_days: ValidityDays = Field(default=365)
     master_owners: list[str] = Field(default_factory=list)
 
     @model_validator(mode="after")
@@ -43,7 +45,7 @@ class SecretConfig(BaseModel):
     keyvault_secret_description: Optional[str] = Field(default=None)
     required_owners: list[str] = Field(default_factory=list)
     threshold_days: Optional[int] = Field(default=None, ge=0, le=365)
-    validity_days: Optional[int] = Field(default=None, ge=1, le=730)
+    validity_days: Optional[ValidityDays] = Field(default=None)
 
     @model_validator(mode="after")
     def _validity_exceeds_threshold(self) -> "SecretConfig":

--- a/srf/graph/client.py
+++ b/srf/graph/client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from datetime import datetime, timedelta, timezone
 
 from azure.core.credentials import TokenCredential
@@ -16,6 +17,7 @@ from msgraph.generated.models.reference_create import ReferenceCreate
 
 
 _GRAPH_SCOPES = ["https://graph.microsoft.com/.default"]
+logger = logging.getLogger(__name__)
 
 
 class GraphClient:

--- a/srf/rotation/rotator.py
+++ b/srf/rotation/rotator.py
@@ -58,8 +58,9 @@ class SecretRotator:
 
     # ------------------------------------------------------------------
 
-    def needs_rotation(self, credentials: list[PasswordCredential]) -> tuple[bool, Optional[datetime]]:
+    def needs_rotation(self, credentials: list[PasswordCredential], threshold: Optional[timedelta] = None) -> tuple[bool, Optional[datetime]]:
         """Return (needs_rotation, soonest_expiry) for the credential set."""
+        effective_threshold = threshold if threshold is not None else self._threshold
         if not credentials:
             return True, None
 
@@ -76,7 +77,7 @@ class SecretRotator:
                 expiry = expiry.replace(tzinfo=timezone.utc)
             if soonest is None or expiry < soonest:
                 soonest = expiry
-            if expiry <= now + self._threshold:
+            if expiry <= now + effective_threshold:
                 return True, soonest
 
         return False, soonest
@@ -85,10 +86,20 @@ class SecretRotator:
 
     def rotate(self, secret_config: SecretConfig) -> RotationResult:
         vault_name = _vault_name_from_id(secret_config.keyvault_id)
+        eff_threshold = (
+            timedelta(days=secret_config.threshold_days)
+            if secret_config.threshold_days is not None
+            else self._threshold
+        )
+        eff_validity = (
+            secret_config.validity_days
+            if secret_config.validity_days is not None
+            else self._validity_days
+        )
         try:
             credentials = self._graph.list_password_credentials(secret_config.app_id)
             was_created = len(credentials) == 0
-            should_rotate, current_expiry = self.needs_rotation(credentials)
+            should_rotate, current_expiry = self.needs_rotation(credentials, threshold=eff_threshold)
 
             if not should_rotate:
                 if self._dry_run:
@@ -124,7 +135,7 @@ class SecretRotator:
             new_cred = self._graph.add_password_credential(
                 app_id=secret_config.app_id,
                 display_name=f"rotated-by-srf",
-                validity_days=self._validity_days,
+                validity_days=eff_validity,
             )
 
             kv = self._kv_factory(secret_config.keyvault_id)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -217,3 +217,53 @@ def test_master_owners_from_yaml(tmp_path):
         "00000000-0000-0000-0000-000000000001",
         "00000000-0000-0000-0000-000000000002",
     ]
+
+
+def test_per_secret_threshold_and_validity_days(tmp_path):
+    yaml_text = textwrap.dedent("""\
+        main:
+          tenant_id: tid
+        secrets:
+          - name: sp1
+            app_id: app-001
+            keyvault_id: /subscriptions/s/resourceGroups/r/providers/Microsoft.KeyVault/vaults/sp-kv
+            keyvault_secret_name: sp1-secret
+            threshold_days: 30
+            validity_days: 180
+    """)
+    cfg_file = tmp_path / "cfg.yaml"
+    cfg_file.write_text(yaml_text)
+
+    cfg = load_config(str(cfg_file))
+
+    assert cfg.secrets[0].threshold_days == 30
+    assert cfg.secrets[0].validity_days == 180
+
+
+def test_per_secret_defaults_are_none(tmp_path):
+    cfg_file = tmp_path / "cfg.yaml"
+    cfg_file.write_text(MINIMAL_YAML)
+
+    cfg = load_config(str(cfg_file))
+
+    assert cfg.secrets[0].threshold_days is None
+    assert cfg.secrets[0].validity_days is None
+
+
+def test_per_secret_validity_must_exceed_threshold(tmp_path):
+    yaml_text = textwrap.dedent("""\
+        main:
+          tenant_id: tid
+        secrets:
+          - name: sp1
+            app_id: app-001
+            keyvault_id: /subscriptions/s/resourceGroups/r/providers/Microsoft.KeyVault/vaults/sp-kv
+            keyvault_secret_name: sp1-secret
+            threshold_days: 60
+            validity_days: 60
+    """)
+    cfg_file = tmp_path / "bad.yaml"
+    cfg_file.write_text(yaml_text)
+
+    with pytest.raises(Exception, match="validity_days"):
+        load_config(str(cfg_file))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -166,14 +166,14 @@ def test_threshold_days_negative_raises(tmp_path):
         load_config(str(cfg_file))
 
 
-def test_validity_days_out_of_range_raises(tmp_path):
+def test_validity_days_invalid_value_raises(tmp_path):
     yaml_text = textwrap.dedent("""\
         main:
           tenant_id: tid
           master_client_id: cid
           master_keyvault_id: /subscriptions/s/resourceGroups/r/providers/Microsoft.KeyVault/vaults/kv
           master_keyvault_secret_name: sec
-          validity_days: 731
+          validity_days: 200
         secrets: []
     """)
     cfg_file = tmp_path / "bad.yaml"

--- a/tests/test_rotator.py
+++ b/tests/test_rotator.py
@@ -303,3 +303,108 @@ def test_dry_run_was_created_true_no_prior_creds():
     assert result.was_created is True
     graph.add_password_credential.assert_not_called()
     kv.set_secret.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# per-secret threshold_days / validity_days overrides
+# ---------------------------------------------------------------------------
+
+def test_per_secret_threshold_triggers_earlier_rotation():
+    """Secret with threshold_days=20 should rotate a cred expiring in 15 days."""
+    new_cred = MagicMock()
+    new_cred.key_id = "key-new"
+    new_cred.secret_text = "s"
+    new_cred.end_date_time = NOW + timedelta(days=365)
+
+    graph = MagicMock()
+    graph.list_password_credentials.return_value = [_cred(15)]  # outside global 7-day threshold
+    graph.add_password_credential.return_value = new_cred
+
+    rotator = _make_rotator(graph, MagicMock())
+    cfg = SecretConfig(
+        name="sp1", app_id="app-0001", keyvault_id=KV_ID,
+        keyvault_secret_name="sp1-secret", threshold_days=20,
+    )
+
+    result = rotator.rotate(cfg)
+    assert result.rotated is True
+
+
+def test_per_secret_threshold_suppresses_rotation():
+    """Secret with threshold_days=3 should skip a cred expiring in 5 days (global=7 would rotate)."""
+    graph = MagicMock()
+    graph.list_password_credentials.return_value = [_cred(5)]  # within global 7-day threshold
+
+    rotator = _make_rotator(graph, MagicMock())
+    cfg = SecretConfig(
+        name="sp1", app_id="app-0001", keyvault_id=KV_ID,
+        keyvault_secret_name="sp1-secret", threshold_days=3,
+    )
+
+    result = rotator.rotate(cfg)
+    assert result.rotated is False
+    assert result.error is None
+
+
+def test_per_secret_validity_days_used_in_add_credential():
+    """add_password_credential should be called with per-secret validity_days."""
+    new_cred = MagicMock()
+    new_cred.key_id = "key-new"
+    new_cred.secret_text = "s"
+    new_cred.end_date_time = NOW + timedelta(days=180)
+
+    graph = MagicMock()
+    graph.list_password_credentials.return_value = [_cred(-1)]
+    graph.add_password_credential.return_value = new_cred
+
+    rotator = _make_rotator(graph, MagicMock())
+    cfg = SecretConfig(
+        name="sp1", app_id="app-0001", keyvault_id=KV_ID,
+        keyvault_secret_name="sp1-secret", validity_days=180,
+    )
+
+    rotator.rotate(cfg)
+    graph.add_password_credential.assert_called_once_with(
+        app_id="app-0001",
+        display_name="rotated-by-srf",
+        validity_days=180,
+    )
+
+
+def test_per_secret_validity_validator_rejects_invalid():
+    """validity_days <= threshold_days on the same secret must raise."""
+    with pytest.raises(Exception, match="validity_days"):
+        SecretConfig(
+            name="sp1", app_id="app-0001", keyvault_id=KV_ID,
+            keyvault_secret_name="sp1-secret",
+            threshold_days=30, validity_days=30,
+        )
+
+
+def test_per_secret_only_threshold_no_validity_uses_global_validity():
+    """When only threshold_days is overridden, global validity_days is still used."""
+    new_cred = MagicMock()
+    new_cred.key_id = "key-new"
+    new_cred.secret_text = "s"
+    new_cred.end_date_time = NOW + timedelta(days=365)
+
+    graph = MagicMock()
+    graph.list_password_credentials.return_value = [_cred(-1)]
+    graph.add_password_credential.return_value = new_cred
+
+    rotator = SecretRotator(
+        graph_client=graph,
+        keyvault_client_factory=lambda _: MagicMock(),
+        validity_days=270,
+    )
+    cfg = SecretConfig(
+        name="sp1", app_id="app-0001", keyvault_id=KV_ID,
+        keyvault_secret_name="sp1-secret", threshold_days=14,
+    )
+
+    rotator.rotate(cfg)
+    graph.add_password_credential.assert_called_once_with(
+        app_id="app-0001",
+        display_name="rotated-by-srf",
+        validity_days=270,
+    )

--- a/tests/test_rotator.py
+++ b/tests/test_rotator.py
@@ -395,7 +395,7 @@ def test_per_secret_only_threshold_no_validity_uses_global_validity():
     rotator = SecretRotator(
         graph_client=graph,
         keyvault_client_factory=lambda _: MagicMock(),
-        validity_days=270,
+        validity_days=180,
     )
     cfg = SecretConfig(
         name="sp1", app_id="app-0001", keyvault_id=KV_ID,
@@ -406,5 +406,5 @@ def test_per_secret_only_threshold_no_validity_uses_global_validity():
     graph.add_password_credential.assert_called_once_with(
         app_id="app-0001",
         display_name="rotated-by-srf",
-        validity_days=270,
+        validity_days=180,
     )


### PR DESCRIPTION
## Summary

Secrets can now override the global `threshold_days` and `validity_days` set in `main:`. Per-secret values take priority; if omitted, the global values are used as before.

## Changes

- `SecretConfig`: new optional fields `threshold_days` (0–365) and `validity_days` (1–730)
- Validation: rejects `validity_days <= threshold_days` when both are set on the same secret
- `SecretRotator.needs_rotation`: accepts optional threshold override per call
- `SecretRotator.rotate`: resolves effective threshold/validity per-secret before acting
- `config.schema.json`: regenerated from updated Pydantic model
- `input.yaml`: new fields documented with commented examples
- 8 new tests covering overrides, suppression, and validation

## Usage

```yaml
secrets:
  - name: high-turnover-sp
    app_id: ...
    keyvault_id: ...
    keyvault_secret_name: ...
    threshold_days: 30   # rotate earlier than global 7-day default
    validity_days: 180   # shorter-lived secret than global 365-day default
```