### PR TITLE
docs: emphasise branching from up-to-date master

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,9 +28,13 @@ Examples:
 
 ### Workflow
 
+> ⚠️ **Always start a new branch from an up-to-date `master`.**  
+> Never branch from another feature branch or from a stale local `master`.
+
 ```
-# 1. Branch off master
-git checkout master && git pull
+# 1. Update master first, then branch
+git checkout master
+git pull origin master
 git checkout -b feature/my-feature
 
 # 2. Make changes, commit


### PR DESCRIPTION
Always branch from an up-to-date master. Adds a warning callout and splits the workflow commands for clarity.