### PR TITLE
fix: create fresh GraphServiceClient per _run() to fix thread safety

### DIFF
--- a/srf/graph/client.py
+++ b/srf/graph/client.py
@@ -24,25 +24,25 @@ class GraphClient:
     """Thin wrapper around msgraph-sdk for SP password credential operations."""
 
     def __init__(self, credential: TokenCredential) -> None:
-        self._graph = GraphServiceClient(credential, scopes=_GRAPH_SCOPES)
+        self._credential = credential
         self._object_id_cache: dict[str, str] = {}
 
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
 
-    def _run(self, coro):
+    def _run(self, coro_factory):
         """Run an async Graph SDK coroutine synchronously in a thread-safe way.
 
-        ``asyncio.run()`` is not safe to call concurrently from multiple threads
-        because it modifies the running event loop at the process level.
-        We create an isolated event loop per call and tear it down cleanly,
-        including shutting down async generators and the default executor so
-        that aiohttp connection pools are not leaked across threads.
+        A fresh ``GraphServiceClient`` (and its underlying httpx transport) is
+        created for every call so that the async HTTP client is always local to
+        the event loop it runs in.  This makes concurrent calls from different
+        threads safe without requiring any locking.
         """
+        graph = GraphServiceClient(self._credential, scopes=_GRAPH_SCOPES)
         loop = asyncio.new_event_loop()
         try:
-            return loop.run_until_complete(coro)
+            return loop.run_until_complete(coro_factory(graph))
         finally:
             try:
                 loop.run_until_complete(loop.shutdown_asyncgens())
@@ -50,9 +50,10 @@ class GraphClient:
             finally:
                 loop.close()
 
-    async def _get_object_id(self, app_id: str) -> str:
+    async def _get_object_id(self, app_id: str, graph: GraphServiceClient) -> str:
         """Resolve appId (client ID) to the application's object ID (cached)."""
         if app_id in self._object_id_cache:
+            logger.debug("srf.graph.client: object_id cache hit for app_id=%s", app_id)
             return self._object_id_cache[app_id]
 
         from msgraph.generated.applications.applications_request_builder import (
@@ -60,17 +61,19 @@ class GraphClient:
         )
         from kiota_abstractions.base_request_configuration import RequestConfiguration
 
+        logger.debug("srf.graph.client: resolving object_id for app_id=%s via Graph API", app_id)
         query_params = ApplicationsRequestBuilder.ApplicationsRequestBuilderGetQueryParameters(
             filter=f"appId eq '{app_id}'",
             select=["id", "appId"],
         )
         config = RequestConfiguration(query_parameters=query_params)
-        result = await self._graph.applications.get(request_configuration=config)
+        result = await graph.applications.get(request_configuration=config)
         apps = result.value if result and result.value else []
         if not apps:
             raise ValueError(f"Application with appId '{app_id}' not found in the directory.")
         obj_id: str = apps[0].id  # type: ignore[assignment]
         self._object_id_cache[app_id] = obj_id
+        logger.debug("srf.graph.client: resolved app_id=%s -> object_id=%s", app_id, obj_id)
         return obj_id
 
     # ------------------------------------------------------------------
@@ -78,41 +81,45 @@ class GraphClient:
     # ------------------------------------------------------------------
 
     def list_password_credentials(self, app_id: str) -> list[PasswordCredential]:
-        async def _call():
-            obj_id = await self._get_object_id(app_id)
-            app = await self._graph.applications.by_application_id(obj_id).get()
+        logger.debug("srf.graph.client: listing password credentials for app_id=%s", app_id)
+
+        async def _call(graph: GraphServiceClient):
+            obj_id = await self._get_object_id(app_id, graph)
+            app = await graph.applications.by_application_id(obj_id).get()
             return app.password_credentials or []  # type: ignore[union-attr]
 
-        return self._run(_call())
+        return self._run(_call)
 
     def add_password_credential(
         self, app_id: str, display_name: str, validity_days: int = 365
     ) -> PasswordCredential:
-        async def _call():
-            obj_id = await self._get_object_id(app_id)
+        async def _call(graph: GraphServiceClient):
+            obj_id = await self._get_object_id(app_id, graph)
             end_dt = datetime.now(tz=timezone.utc) + timedelta(days=validity_days)
             body = AddPasswordPostRequestBody()
             cred = PasswordCredential()
             cred.display_name = display_name
             cred.end_date_time = end_dt
             body.password_credential = cred
-            return await self._graph.applications.by_application_id(obj_id).add_password.post(body)
+            return await graph.applications.by_application_id(obj_id).add_password.post(body)
 
-        return self._run(_call())
+        return self._run(_call)
 
     def remove_password_credential(self, app_id: str, key_id: str) -> None:
-        async def _call():
-            obj_id = await self._get_object_id(app_id)
+        async def _call(graph: GraphServiceClient):
+            obj_id = await self._get_object_id(app_id, graph)
             body = RemovePasswordPostRequestBody()
             body.key_id = key_id
-            await self._graph.applications.by_application_id(obj_id).remove_password.post(body)
+            await graph.applications.by_application_id(obj_id).remove_password.post(body)
 
-        self._run(_call())
+        self._run(_call)
 
     def list_owners(self, app_id: str) -> list[str]:
-        async def _call():
-            obj_id = await self._get_object_id(app_id)
-            result = await self._graph.applications.by_application_id(obj_id).owners.get()
+        logger.debug("srf.graph.client: listing owners for app_id=%s", app_id)
+
+        async def _call(graph: GraphServiceClient):
+            obj_id = await self._get_object_id(app_id, graph)
+            result = await graph.applications.by_application_id(obj_id).owners.get()
             entries = result.value if result and result.value else []
             return [
                 e.id
@@ -120,13 +127,13 @@ class GraphClient:
                 if getattr(e, "odata_type", None) == "#microsoft.graph.user"
             ]
 
-        return self._run(_call())
+        return self._run(_call)
 
     def add_owner(self, app_id: str, user_object_id: str) -> None:
-        async def _call():
-            obj_id = await self._get_object_id(app_id)
+        async def _call(graph: GraphServiceClient):
+            obj_id = await self._get_object_id(app_id, graph)
             body = ReferenceCreate()
             body.odata_id = f"https://graph.microsoft.com/v1.0/directoryObjects/{user_object_id}"
-            await self._graph.applications.by_application_id(obj_id).owners.ref.post(body)
+            await graph.applications.by_application_id(obj_id).owners.ref.post(body)
 
-        self._run(_call())
+        self._run(_call)


### PR DESCRIPTION
## Problem
`ParallelRunner` processes SPs in a `ThreadPoolExecutor`. Both threads shared the same `GraphClient` instance, which held a single `GraphServiceClient` / `httpx.AsyncClient`. Concurrent `_run()` calls each created a new event loop but reused the same async HTTP client — which is not safe across loops. This caused `RuntimeError` in both rotation and ownership checks for the second SP.

## Fix
Store only the credential in `__init__`. Instantiate a fresh `GraphServiceClient` inside every `_run()` call so the HTTP client is always loop-local. Object-ID cache is preserved for reuse within a single logical call chain.