### PR TITLE
feat: force rotation every run when threshold_days=0

### DIFF
--- a/srf/rotation/rotator.py
+++ b/srf/rotation/rotator.py
@@ -63,10 +63,24 @@ class SecretRotator:
     # ------------------------------------------------------------------
 
     def needs_rotation(self, credentials: list[PasswordCredential], threshold: Optional[timedelta] = None) -> tuple[bool, Optional[datetime]]:
-        """Return (needs_rotation, soonest_expiry) for the credential set."""
+        """Return (needs_rotation, soonest_expiry) for the credential set.
+
+        A threshold of zero is treated as "always rotate": rotation is forced
+        regardless of the current credential expiry.
+        """
         effective_threshold = threshold if threshold is not None else self._threshold
         if not credentials:
             return True, None
+
+        # threshold_days=0 means force rotation on every run
+        if effective_threshold == timedelta(0):
+            now = datetime.now(tz=timezone.utc)
+            soonest = min(
+                (c.end_date_time.replace(tzinfo=timezone.utc) if c.end_date_time and c.end_date_time.tzinfo is None else c.end_date_time)
+                for c in credentials
+                if c.end_date_time is not None
+            ) if any(c.end_date_time is not None for c in credentials) else None
+            return True, soonest
 
         now = datetime.now(tz=timezone.utc)
         soonest: Optional[datetime] = None

--- a/tests/test_rotator.py
+++ b/tests/test_rotator.py
@@ -85,9 +85,75 @@ def test_needs_rotation_returns_soonest_expiry():
     assert abs((soonest - expected).total_seconds()) < 2
 
 
-# ---------------------------------------------------------------------------
-# rotate — no rotation needed
-# ---------------------------------------------------------------------------
+def test_needs_rotation_zero_threshold_always_true():
+    """threshold_days=0 forces rotation regardless of expiry."""
+    rotator = _make_rotator(MagicMock(), MagicMock())
+    result, _ = rotator.needs_rotation([_cred(365)], threshold=timedelta(0))
+    assert result is True
+
+
+def test_needs_rotation_zero_threshold_returns_soonest_expiry():
+    rotator = _make_rotator(MagicMock(), MagicMock())
+    creds = [_cred(90), _cred(30), _cred(180)]
+    _, soonest = rotator.needs_rotation(creds, threshold=timedelta(0))
+    expected = NOW + timedelta(days=30)
+    assert abs((soonest - expected).total_seconds()) < 2
+
+
+def test_rotate_forced_when_per_secret_threshold_is_zero():
+    """A per-secret threshold_days=0 should trigger rotation every run."""
+    new_cred = MagicMock()
+    new_cred.key_id = "key-new"
+    new_cred.secret_text = "s"
+    new_cred.end_date_time = NOW + timedelta(days=365)
+
+    graph = MagicMock()
+    graph.list_password_credentials.return_value = [_cred(30)]  # not normally expiring
+    graph.add_password_credential.return_value = new_cred
+
+    kv = MagicMock()
+    kv.secret_exists.return_value = True
+
+    cfg = SecretConfig(
+        name="sp1",
+        app_id="app-0001",
+        keyvault_id=KV_ID,
+        keyvault_secret_name="sp1-secret",
+        threshold_days=0,
+        validity_days=90,
+    )
+    rotator = _make_rotator(graph, kv)
+    result = rotator.rotate(cfg)
+
+    assert result.rotated is True
+    kv.set_secret.assert_called_once()
+
+
+def test_rotate_forced_when_global_threshold_is_zero():
+    """A global threshold_days=0 should trigger rotation every run."""
+    new_cred = MagicMock()
+    new_cred.key_id = "key-new"
+    new_cred.secret_text = "s"
+    new_cred.end_date_time = NOW + timedelta(days=365)
+
+    graph = MagicMock()
+    graph.list_password_credentials.return_value = [_cred(30)]
+    graph.add_password_credential.return_value = new_cred
+
+    kv = MagicMock()
+    kv.secret_exists.return_value = True
+
+    rotator = SecretRotator(
+        graph_client=graph,
+        keyvault_client_factory=lambda _: kv,
+        threshold_days=0,
+    )
+    result = rotator.rotate(_make_secret_cfg())
+
+    assert result.rotated is True
+    kv.set_secret.assert_called_once()
+
+
 
 def test_rotate_skipped_when_not_expiring():
     graph = MagicMock()


### PR DESCRIPTION
Setting `threshold_days: 0` (globally in `main` or per-secret) now forces rotation on every run, regardless of when the credential expires. Useful for secrets that must be cycled on a fixed schedule.