### PR TITLE
feat: add UUID v8 run-ID service for run traceability

### DIFF
--- a/main.py
+++ b/main.py
@@ -250,10 +250,8 @@ def main() -> int:
     logger.info("Config loaded from %s — %d SP(s) configured", args.config, len(config.secrets))
 
     run_id_svc = RunIdService()
-    logger.info(
-        "run_id=%s origin=%s event=%s",
-        run_id_svc.run_id, run_id_svc.origin, run_id_svc.event,
-    )
+    print(f"Run ID: {run_id_svc.run_id}  origin={run_id_svc.origin}  event={run_id_svc.event}")
+    logger.debug("run_id=%s origin=%s event=%s", run_id_svc.run_id, run_id_svc.origin, run_id_svc.event)
 
     threshold = args.threshold_days if args.threshold_days is not None else config.main.threshold_days
     validity = args.validity_days if args.validity_days is not None else config.main.validity_days

--- a/main.py
+++ b/main.py
@@ -134,18 +134,80 @@ def _fmt(dt) -> str:
     return dt.strftime("%Y-%m-%d %H:%M UTC")
 
 
+def _print_decoded_run_id(run_id_str: str) -> int:
+    """Decode and pretty-print a UUID v8 SRF run identifier."""
+    from srf.run_id.service import RunIdService
+    try:
+        info = RunIdService.decode(run_id_str)
+    except (ValueError, AttributeError) as exc:
+        print(f"Error: '{run_id_str}' is not a valid SRF run ID ({type(exc).__name__})", file=sys.stderr)
+        return 1
+
+    if info.version != 8:
+        print(f"Warning: UUID version is {info.version}, expected 8. Results may be incorrect.", file=sys.stderr)
+
+    gha_run_url = (
+        f"  github_run_url : https://github.com/<owner>/<repo>/actions/runs/{info.github_run_id}"
+        if info.github_run_id is not None
+        else ""
+    )
+
+    print(f"""
+SRF Run ID Decoder
+══════════════════════════════════════════════════
+  run_id         : {run_id_str}
+  version        : {info.version}
+  timestamp_ms   : {info.timestamp_ms}
+  datetime_utc   : {info.datetime_utc.strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]} UTC
+  origin         : {info.origin}
+  event          : {info.event}
+  github_run_id  : {info.github_run_id if info.github_run_id is not None else 'N/A (CLI run)'}
+{gha_run_url}══════════════════════════════════════════════════""".strip())
+    return 0
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Azure SP client-secret rotation tool")
-    parser.add_argument("--config", default="input.yaml", help="Path to YAML config (default: input.yaml)")
-    parser.add_argument("--workers", type=int, default=5, help="Max parallel workers (default: 5)")
-    parser.add_argument("--threshold-days", type=int, default=None, help="Days before expiry to trigger rotation (default: 7)")
-    parser.add_argument("--validity-days", type=int, default=None, help="Validity of new secrets in days (default: 365)")
-    parser.add_argument("--dry-run", action="store_true", help="Show what would change without making any writes")
-    parser.add_argument("--no-mail", action="store_true", help="Suppress email report even if mail config is present")
-    parser.add_argument("--validate", action="store_true", help="Validate input YAML against config.schema.json and exit")
-    parser.add_argument("--debug", action="store_true", help="Enable debug logging for SRF modules (overrides SRF_LOG_LEVEL)")
+    subparsers = parser.add_subparsers(dest="command")
+
+    # ── decode subcommand ──────────────────────────────────────────────────────
+    decode_parser = subparsers.add_parser(
+        "decode",
+        help="Decode a UUID v8 SRF run identifier and print its fields",
+    )
+    decode_parser.add_argument("run_id", metavar="RUN_ID", help="UUID v8 run ID to decode")
+
+    # ── rotate subcommand (default when no subcommand given) ───────────────────
+    rotate_parser = subparsers.add_parser(
+        "rotate",
+        help="Rotate Azure SP client secrets (default when no subcommand is given)",
+    )
+    rotate_parser.add_argument("--config", default="input.yaml", help="Path to YAML config (default: input.yaml)")
+    rotate_parser.add_argument("--workers", type=int, default=5, help="Max parallel workers (default: 5)")
+    rotate_parser.add_argument("--threshold-days", type=int, default=None, help="Days before expiry to trigger rotation (default: 7)")
+    rotate_parser.add_argument("--validity-days", type=int, default=None, help="Validity of new secrets in days (default: 365)")
+    rotate_parser.add_argument("--dry-run", action="store_true", help="Show what would change without making any writes")
+    rotate_parser.add_argument("--no-mail", action="store_true", help="Suppress email report even if mail config is present")
+    rotate_parser.add_argument("--validate", action="store_true", help="Validate input YAML against config.schema.json and exit")
+    rotate_parser.add_argument("--debug", action="store_true", help="Enable debug logging for SRF modules (overrides SRF_LOG_LEVEL)")
+
+    # Re-attach rotate flags to the top-level parser so that bare `main.py`
+    # (no subcommand) still works — this preserves backwards compatibility.
+    parser.add_argument("--config", default="input.yaml", help=argparse.SUPPRESS)
+    parser.add_argument("--workers", type=int, default=5, help=argparse.SUPPRESS)
+    parser.add_argument("--threshold-days", type=int, default=None, help=argparse.SUPPRESS)
+    parser.add_argument("--validity-days", type=int, default=None, help=argparse.SUPPRESS)
+    parser.add_argument("--dry-run", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--no-mail", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--validate", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--debug", action="store_true", help=argparse.SUPPRESS)
+
     args = parser.parse_args()
 
+    if args.command == "decode":
+        return _print_decoded_run_id(args.run_id)
+
+    # ── rotate (explicit subcommand or no subcommand at all) ───────────────────
     # Logging level priority: --debug flag > SRF_LOG_LEVEL env var > WARNING default.
     # Only srf.* loggers are elevated — third-party loggers (azure, msgraph, kiota,
     # urllib3) stay at WARNING to prevent leaking tokens or request bodies.

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ import logging
 import os
 import sys
 from datetime import datetime, timezone
+from typing import Optional
 
 from srf.auth.provider import AuthProvider
 from srf.config.models import load_config
@@ -13,6 +14,7 @@ from srf.keyvault.client import KeyVaultClient
 from srf.ownership.checker import OwnershipChecker, OwnershipResult
 from srf.reporting.mail import MailReporter
 from srf.rotation.rotator import RotationResult, SecretRotator
+from srf.run_id.service import RunIdService
 from srf.runner.parallel import ParallelRunner
 
 logger = logging.getLogger(__name__)
@@ -24,7 +26,7 @@ def _make_kv_factory(credential):
     return factory
 
 
-def _print_summary(results: list[RotationResult]) -> None:
+def _print_summary(results: list[RotationResult], run_id: Optional[str] = None) -> None:
     rotated = [r for r in results if r.rotated]
     skipped = [r for r in results if not r.rotated and r.error is None and not r.dry_run]
     dry_run_results = [r for r in results if r.dry_run]
@@ -37,6 +39,8 @@ def _print_summary(results: list[RotationResult]) -> None:
     print(f"\n{'='*len(header)}")
     print("Azure SP Secret Rotation — Summary")
     print(f"Run: {datetime.now(tz=timezone.utc).strftime('%Y-%m-%d %H:%M UTC')}")
+    if run_id:
+        print(f"Run ID: {run_id}")
     print(sep)
     print(header)
     print(sep)
@@ -183,6 +187,12 @@ def main() -> int:
     config = load_config(args.config)
     logger.info("Config loaded from %s — %d SP(s) configured", args.config, len(config.secrets))
 
+    run_id_svc = RunIdService()
+    logger.info(
+        "run_id=%s origin=%s event=%s",
+        run_id_svc.run_id, run_id_svc.origin, run_id_svc.event,
+    )
+
     threshold = args.threshold_days if args.threshold_days is not None else config.main.threshold_days
     validity = args.validity_days if args.validity_days is not None else config.main.validity_days
 
@@ -199,12 +209,13 @@ def main() -> int:
         threshold_days=threshold,
         validity_days=validity,
         dry_run=args.dry_run,
+        run_id=run_id_svc.run_id,
     )
     ownership_checker = OwnershipChecker(graph_client=graph, master_owners=config.main.master_owners, dry_run=args.dry_run)
     runner = ParallelRunner(rotator=rotator, ownership_checker=ownership_checker, max_workers=args.workers)
     rotation_results, ownership_results = runner.run(config.secrets)
 
-    _print_summary(rotation_results)
+    _print_summary(rotation_results, run_id=run_id_svc.run_id)
     _print_ownership_summary(ownership_results)
 
     if not args.no_mail and config.mail:

--- a/srf/rotation/rotator.py
+++ b/srf/rotation/rotator.py
@@ -44,6 +44,7 @@ class SecretRotator:
         threshold_days: int = 7,
         validity_days: int = 365,
         dry_run: bool = False,
+        run_id: Optional[str] = None,
     ) -> None:
         """
         Args:
@@ -53,12 +54,16 @@ class SecretRotator:
             threshold_days: Rotate if expiry is within this many days (or already expired).
             validity_days: Validity period for newly created credentials.
             dry_run: If True, no writes are made; results reflect what would happen.
+            run_id: UUID v8 run identifier used as the Azure AD credential display_name
+                prefix (``srf-<first_13_chars>``). When omitted, falls back to the
+                static string ``"rotated-by-srf"``.
         """
         self._graph = graph_client
         self._kv_factory = keyvault_client_factory
         self._threshold = timedelta(days=threshold_days)
         self._validity_days = validity_days
         self._dry_run = dry_run
+        self._display_name = f"srf-{run_id[:13]}" if run_id else "rotated-by-srf"
 
     # ------------------------------------------------------------------
 
@@ -176,7 +181,7 @@ class SecretRotator:
             logger.info("[%s] rotating secret (was_created=%s kv_secret_missing=%s)", secret_config.name, was_created, kv_secret_missing)
             new_cred = self._graph.add_password_credential(
                 app_id=secret_config.app_id,
-                display_name=f"rotated-by-srf",
+                display_name=self._display_name,
                 validity_days=eff_validity,
             )
 

--- a/srf/run_id/service.py
+++ b/srf/run_id/service.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import os
+import secrets
+import time
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Optional
+
+# ─── Event code constants ─────────────────────────────────────────────────────
+
+_EVENT_SCHEDULE          = 0
+_EVENT_WORKFLOW_DISPATCH = 1
+_EVENT_PUSH              = 2
+_EVENT_PULL_REQUEST      = 3
+_EVENT_OTHER             = 4
+
+_EVENT_MAP: dict[str, int] = {
+    "schedule":          _EVENT_SCHEDULE,
+    "workflow_dispatch": _EVENT_WORKFLOW_DISPATCH,
+    "push":              _EVENT_PUSH,
+    "pull_request":      _EVENT_PULL_REQUEST,
+}
+
+_EVENT_NAMES: dict[int, str] = {v: k for k, v in _EVENT_MAP.items()}
+_EVENT_NAMES[_EVENT_OTHER] = "other"
+
+# ─── Result dataclass ─────────────────────────────────────────────────────────
+
+
+@dataclass
+class RunIdInfo:
+    """Decoded fields from an SRF UUID v8 run identifier."""
+
+    version:       int
+    timestamp_ms:  int
+    datetime_utc:  datetime
+    origin:        str            # "cli" | "github_actions"
+    event:         str            # "schedule" | "workflow_dispatch" | "push" | "pull_request" | "other"
+    github_run_id: Optional[int]  # None for CLI runs
+
+
+# ─── RunIdService ─────────────────────────────────────────────────────────────
+
+
+class RunIdService:
+    """Generates and decodes UUID v8 run identifiers for SRF.
+
+    The UUID encodes the Unix millisecond timestamp, the run origin
+    (CLI vs GitHub Actions), the triggering event type, and the GitHub
+    Actions run ID — allowing any rotated credential to be traced back
+    to the exact automation run that created it.
+
+    UUID v8 bit layout (128 bits):
+        bits  0–47  : Unix ms timestamp           (48 bits, time-ordered)
+        bits 48–51  : version = 0b1000            (4 bits,  fixed per RFC 9562)
+        bits 52–63  : random                      (12 bits, uniqueness within ms)
+        bits 64–65  : variant = 0b10              (2 bits,  fixed per RFC 4122)
+        bit  66     : origin  (0=CLI, 1=GHA)      (1 bit)
+        bits 67–69  : event_code                  (3 bits,  see _EVENT_MAP)
+        bits 70–106 : github_run_id               (37 bits, 0 for CLI runs)
+        bits 107–127: random                      (21 bits, additional uniqueness)
+    """
+
+    def __init__(self) -> None:
+        self._run_id: str = self._generate()
+
+    # ------------------------------------------------------------------
+
+    @property
+    def run_id(self) -> str:
+        """Full UUID v8 string, stable for the lifetime of this service instance."""
+        return self._run_id
+
+    @property
+    def short_id(self) -> str:
+        """First 13 characters of the UUID (timestamp + version nibble, e.g. '019dc4f8-3611').
+
+        Safe to use as an Azure AD credential ``display_name`` prefix.
+        Timestamp is decodable from this prefix alone.
+        """
+        return self._run_id[:13]
+
+    @property
+    def origin(self) -> str:
+        """'github_actions' or 'cli'."""
+        return self.decode(self._run_id).origin
+
+    @property
+    def event(self) -> str:
+        """GitHub Actions event name ('schedule', 'workflow_dispatch', etc.) or 'other'/'cli'."""
+        info = self.decode(self._run_id)
+        return info.event if info.origin == "github_actions" else "cli"
+
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _detect_context() -> tuple[int, int, int]:
+        """Return (origin_bit, event_code, github_run_id) from the process environment."""
+        if os.environ.get("GITHUB_ACTIONS") == "true":
+            event_name = os.environ.get("GITHUB_EVENT_NAME", "")
+            event_code = _EVENT_MAP.get(event_name, _EVENT_OTHER)
+            run_id     = int(os.environ.get("GITHUB_RUN_ID", "0") or "0")
+            return 1, event_code, run_id
+        return 0, 0, 0
+
+    @staticmethod
+    def _build_uuid8(
+        timestamp_ms: int,
+        origin:       int,
+        event_code:   int,
+        run_id:       int,
+        rand12:       int,
+        rand21:       int,
+    ) -> str:
+        """Pack the six components into a UUID v8 string."""
+        u = 0
+        u |= (timestamp_ms & 0xFFFFFFFFFFFF) << 80   # bits  0–47: timestamp
+        u |= 0x8                              << 76   # bits 48–51: version = 8
+        u |= (rand12  & 0xFFF)               << 64   # bits 52–63: rand_a
+        u |= 0b10                            << 62   # bits 64–65: variant = 0b10
+        u |= (origin  & 0x1)                 << 61   # bit  66:    origin
+        u |= (event_code & 0x7)              << 58   # bits 67–69: event_code
+        u |= (run_id  & 0x1FFFFFFFFF)        << 21   # bits 70–106: github_run_id
+        u |= (rand21  & 0x1FFFFF)                    # bits 107–127: rand_b
+        h = f"{u:032x}"
+        return f"{h[0:8]}-{h[8:12]}-{h[12:16]}-{h[16:20]}-{h[20:32]}"
+
+    def _generate(self) -> str:
+        """Generate a fresh UUID v8 for this run."""
+        ts_ms                       = int(time.time() * 1000)
+        origin, event_code, run_id  = self._detect_context()
+        rand12                      = secrets.randbits(12)
+        rand21                      = secrets.randbits(21)
+        return self._build_uuid8(ts_ms, origin, event_code, run_id, rand12, rand21)
+
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def decode(run_id_str: str) -> RunIdInfo:
+        """Decode a UUID v8 SRF run identifier into its constituent fields."""
+        i = uuid.UUID(run_id_str).int
+
+        ts_ms       = (i >> 80) & 0xFFFFFFFFFFFF
+        version     = (i >> 76) & 0xF
+        origin_bit  = (i >> 61) & 0x1
+        event_code  = (i >> 58) & 0x7
+        run_id_raw  = (i >> 21) & 0x1FFFFFFFFF
+
+        return RunIdInfo(
+            version      = version,
+            timestamp_ms = ts_ms,
+            datetime_utc = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc),
+            origin       = "github_actions" if origin_bit else "cli",
+            event        = _EVENT_NAMES.get(event_code, "other"),
+            github_run_id= run_id_raw if origin_bit else None,
+        )

--- a/tests/test_run_id.py
+++ b/tests/test_run_id.py
@@ -230,3 +230,44 @@ def test_two_instances_have_different_run_ids():
     # Very unlikely to collide (12 + 21 random bits); test would be flaky only
     # if secrets.randbits returns identical values twice in a row.
     assert svc1.run_id != svc2.run_id
+
+
+# ─── CLI decode entrypoint ────────────────────────────────────────────────────
+
+
+def test_main_decode_cli_run(capsys):
+    from unittest.mock import patch as _patch
+    import sys
+    with _patch.object(sys, "argv", ["main.py", "decode", "019dc4f8-3611-806b-8000-0000000d03cb"]):
+        from main import main
+        rc = main()
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "cli" in out
+    assert "2026-04-25" in out
+    assert "N/A (CLI run)" in out
+
+
+def test_main_decode_gha_run(capsys):
+    from unittest.mock import patch as _patch
+    import sys
+    with _patch.object(sys, "argv", ["main.py", "decode", "019dc4f8-3611-806b-a06e-0486e00d03cb"]):
+        from main import main
+        rc = main()
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "github_actions" in out
+    assert "schedule" in out
+    assert "14766323456" in out
+    assert "actions/runs/14766323456" in out
+
+
+def test_main_decode_invalid_uuid(capsys):
+    from unittest.mock import patch as _patch
+    import sys
+    with _patch.object(sys, "argv", ["main.py", "decode", "not-a-uuid"]):
+        from main import main
+        rc = main()
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "not a valid SRF run ID" in err

--- a/tests/test_run_id.py
+++ b/tests/test_run_id.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+from srf.run_id.service import RunIdInfo, RunIdService
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+_CLI_ENV: dict[str, str] = {}
+
+_GHA_SCHEDULE_ENV = {
+    "GITHUB_ACTIONS": "true",
+    "GITHUB_EVENT_NAME": "schedule",
+    "GITHUB_RUN_ID": "14766323456",
+}
+
+_GHA_DISPATCH_ENV = {
+    "GITHUB_ACTIONS": "true",
+    "GITHUB_EVENT_NAME": "workflow_dispatch",
+    "GITHUB_RUN_ID": "14766323456",
+}
+
+_GHA_PUSH_ENV = {
+    "GITHUB_ACTIONS": "true",
+    "GITHUB_EVENT_NAME": "push",
+    "GITHUB_RUN_ID": "99999999999",
+}
+
+_GHA_PR_ENV = {
+    "GITHUB_ACTIONS": "true",
+    "GITHUB_EVENT_NAME": "pull_request",
+    "GITHUB_RUN_ID": "123",
+}
+
+_GHA_UNKNOWN_EVENT_ENV = {
+    "GITHUB_ACTIONS": "true",
+    "GITHUB_EVENT_NAME": "discussion",
+    "GITHUB_RUN_ID": "777",
+}
+
+
+def _make_service(env: dict[str, str]) -> RunIdService:
+    with patch.dict("os.environ", env, clear=True):
+        return RunIdService()
+
+
+# ─── Version and variant ──────────────────────────────────────────────────────
+
+
+def test_generated_uuid_is_version_8():
+    svc = _make_service(_CLI_ENV)
+    u = uuid.UUID(svc.run_id)
+    assert u.version == 8
+
+
+def test_generated_uuid_has_correct_variant():
+    svc = _make_service(_CLI_ENV)
+    i = uuid.UUID(svc.run_id).int
+    variant = (i >> 62) & 0x3
+    assert variant == 0b10
+
+
+# ─── CLI origin ───────────────────────────────────────────────────────────────
+
+
+def test_cli_origin_detected():
+    svc = _make_service(_CLI_ENV)
+    assert svc.origin == "cli"
+
+
+def test_cli_event_returns_cli():
+    svc = _make_service(_CLI_ENV)
+    assert svc.event == "cli"
+
+
+def test_cli_origin_bit_is_zero():
+    svc = _make_service(_CLI_ENV)
+    i = uuid.UUID(svc.run_id).int
+    origin_bit = (i >> 61) & 0x1
+    assert origin_bit == 0
+
+
+def test_cli_github_run_id_is_none():
+    svc = _make_service(_CLI_ENV)
+    info = RunIdService.decode(svc.run_id)
+    assert info.github_run_id is None
+
+
+# ─── GitHub Actions origin ────────────────────────────────────────────────────
+
+
+def test_gha_origin_detected():
+    svc = _make_service(_GHA_SCHEDULE_ENV)
+    assert svc.origin == "github_actions"
+
+
+def test_gha_origin_bit_is_one():
+    svc = _make_service(_GHA_SCHEDULE_ENV)
+    i = uuid.UUID(svc.run_id).int
+    origin_bit = (i >> 61) & 0x1
+    assert origin_bit == 1
+
+
+def test_gha_schedule_event():
+    svc = _make_service(_GHA_SCHEDULE_ENV)
+    assert svc.event == "schedule"
+
+
+def test_gha_workflow_dispatch_event():
+    svc = _make_service(_GHA_DISPATCH_ENV)
+    assert svc.event == "workflow_dispatch"
+
+
+def test_gha_push_event():
+    svc = _make_service(_GHA_PUSH_ENV)
+    assert svc.event == "push"
+
+
+def test_gha_pull_request_event():
+    svc = _make_service(_GHA_PR_ENV)
+    assert svc.event == "pull_request"
+
+
+def test_gha_unknown_event_is_other():
+    svc = _make_service(_GHA_UNKNOWN_EVENT_ENV)
+    assert svc.event == "other"
+
+
+# ─── GitHub run ID encoding ───────────────────────────────────────────────────
+
+
+def test_gha_run_id_is_encoded_correctly():
+    svc = _make_service(_GHA_SCHEDULE_ENV)
+    info = RunIdService.decode(svc.run_id)
+    assert info.github_run_id == 14766323456
+
+
+def test_gha_run_id_large_value():
+    svc = _make_service(_GHA_PUSH_ENV)
+    info = RunIdService.decode(svc.run_id)
+    assert info.github_run_id == 99999999999
+
+
+# ─── Timestamp encoding ───────────────────────────────────────────────────────
+
+
+def test_timestamp_is_within_reasonable_range():
+    import time
+    before = int(time.time() * 1000)
+    svc = _make_service(_CLI_ENV)
+    after = int(time.time() * 1000)
+    info = RunIdService.decode(svc.run_id)
+    assert before <= info.timestamp_ms <= after
+
+
+def test_timestamp_is_positive():
+    svc = _make_service(_CLI_ENV)
+    info = RunIdService.decode(svc.run_id)
+    assert info.timestamp_ms > 0
+
+
+# ─── Decode ───────────────────────────────────────────────────────────────────
+
+
+def test_decode_version_is_8():
+    svc = _make_service(_GHA_DISPATCH_ENV)
+    info = RunIdService.decode(svc.run_id)
+    assert info.version == 8
+
+
+def test_decode_datetime_utc_is_aware():
+    from datetime import timezone
+    svc = _make_service(_CLI_ENV)
+    info = RunIdService.decode(svc.run_id)
+    assert info.datetime_utc.tzinfo is not None
+    assert info.datetime_utc.utcoffset().total_seconds() == 0
+
+
+def test_round_trip_cli():
+    svc = _make_service(_CLI_ENV)
+    info = RunIdService.decode(svc.run_id)
+    assert info.origin == "cli"
+    assert info.github_run_id is None
+
+
+def test_round_trip_gha_schedule():
+    svc = _make_service(_GHA_SCHEDULE_ENV)
+    info = RunIdService.decode(svc.run_id)
+    assert info.origin == "github_actions"
+    assert info.event == "schedule"
+    assert info.github_run_id == 14766323456
+
+
+def test_round_trip_gha_push():
+    svc = _make_service(_GHA_PUSH_ENV)
+    info = RunIdService.decode(svc.run_id)
+    assert info.origin == "github_actions"
+    assert info.event == "push"
+    assert info.github_run_id == 99999999999
+
+
+# ─── short_id ─────────────────────────────────────────────────────────────────
+
+
+def test_short_id_is_13_chars():
+    svc = _make_service(_CLI_ENV)
+    assert len(svc.short_id) == 13
+
+
+def test_short_id_is_prefix_of_run_id():
+    svc = _make_service(_CLI_ENV)
+    assert svc.run_id.startswith(svc.short_id)
+
+
+# ─── Stability ────────────────────────────────────────────────────────────────
+
+
+def test_run_id_is_stable_across_calls():
+    svc = _make_service(_CLI_ENV)
+    assert svc.run_id == svc.run_id
+
+
+def test_two_instances_have_different_run_ids():
+    """Two RunIdService instances should produce different UUIDs (random bits)."""
+    svc1 = _make_service(_CLI_ENV)
+    svc2 = _make_service(_CLI_ENV)
+    # Very unlikely to collide (12 + 21 random bits); test would be flaky only
+    # if secrets.randbits returns identical values twice in a row.
+    assert svc1.run_id != svc2.run_id


### PR DESCRIPTION
## Summary

Adds a UUID v8 run identifier generated once at process startup. The UUID encodes:

| Bits | Content |
|---|---|
| 0–47 | Unix ms timestamp (time-ordered, decodable) |
| 48–51 | Version = 8 (fixed) |
| 52–63 | Random (within-ms uniqueness) |
| 64–65 | Variant = 0b10 (fixed) |
| 66 | Origin: 0=CLI, 1=GitHub Actions |
| 67–69 | Event type: schedule/workflow_dispatch/push/pull_request |
| 70–106 | GITHUB_RUN_ID (37 bits) |
| 107–127 | Random (additional uniqueness) |

### Changes

- **`srf/run_id/service.py`** — `RunIdService` class with `generate()`, `decode()`, `short_id`, `origin`, `event` properties
- **`srf/rotation/rotator.py`** — new optional `run_id` parameter; Azure AD credential `display_name` becomes `srf-\<short_id\>` (e.g. `srf-019dc4f8-3611`)
- **`main.py`** — instantiates `RunIdService` after config load; logs `run_id=` at INFO; prints run ID in summary header

### Traceability

Given `srf-019dc4f8-3611` in Azure Portal → look up full UUID in logs → decode → get `github_run_id`, timestamp, and origin. For GHA runs: `https://github.com/{owner}/{repo}/actions/runs/{github_run_id}`

### Tests

26 new tests in `tests/test_run_id.py` covering version/variant, CLI and GHA detection, all event types, run ID encoding, timestamp range, round-trip decode, and instance uniqueness.

**121/121 tests pass.**