### PR TITLE
fix: store run_id on SecretRotator, forward to Key Vault, and fix CLI event decode

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -98,6 +98,7 @@ tests/
 - Commits: [Conventional Commits](https://www.conventionalcommits.org/) — `feat:`, `fix:`, `chore:`, `style:`, `test:`, `docs:`
 - One feature/fix per PR; all CI checks must be green before merging.
 - Target branch: `master`
+- Don't add copilot as Co-Author in commit messages — the commit history should reflect human authorship only.
 
 ---
 

--- a/.github/workflows/srf-run-oidc.yml
+++ b/.github/workflows/srf-run-oidc.yml
@@ -25,7 +25,7 @@ name: SRF — SP Rotation (OIDC, zero-secrets)
 #     - name: my-sp
 #       app_id: <target SP client ID>
 #       keyvault_id: /subscriptions/.../vaults/my-kv
-#       keyvault_secret_name: my-sp-secret
+#       secret_name: my-sp-secret
 
 on:
   schedule:

--- a/.github/workflows/srf-run-secret.yml
+++ b/.github/workflows/srf-run-secret.yml
@@ -21,7 +21,7 @@ name: SRF — SP Rotation (GitHub Secret)
 #     - name: my-sp
 #       app_id: <target SP client ID>
 #       keyvault_id: /subscriptions/.../vaults/my-kv
-#       keyvault_secret_name: my-sp-secret
+#       secret_name: my-sp-secret
 
 on:
   schedule:

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ poetry install
 poetry run python main.py
 
 # Run tests
-poetry run pytest tests\ -v
+poetry run pytest tests -v
 ```
 
 ### Without Poetry (plain pip)
@@ -152,7 +152,7 @@ main:
   tenant_id: <your-tenant-id>
   master_client_id: <master-sp-client-id>
   master_keyvault_id: /subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.KeyVault/vaults/<kv>
-  master_keyvault_secret_name: master-sp-client-secret
+  master_secret_name: master-sp-client-secret
 ```
 
 ---
@@ -178,7 +178,7 @@ main:
   # ARM resource ID of the Key Vault holding the master SP's own client secret.
   # Omit both fields if using the SRF_MASTER_CLIENT_SECRET env var instead.
   master_keyvault_id: /subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.KeyVault/vaults/<kv-name>
-  master_keyvault_secret_name: master-sp-client-secret
+  master_secret_name: master-sp-client-secret
 
   # Rotation settings (can be overridden per-run with CLI flags)
   threshold_days: 7     # rotate if secret expires within this many days
@@ -206,7 +206,7 @@ secrets:
 
     # Key Vault where the rotated secret value will be stored
     keyvault_id: /subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.KeyVault/vaults/<kv-name>
-    keyvault_secret_name: my-service-sp-secret
+    secret_name: my-service-sp-secret
     keyvault_secret_description: "Managed by SRF"   # optional, stored as KV content_type
 
     # Users added as owner for THIS SP only (merged with master_owners)
@@ -223,7 +223,7 @@ secrets:
 | `tenant_id` | ✅ | — | Azure AD tenant ID |
 | `master_client_id` | ✅ | — | Client ID of the master SP |
 | `master_keyvault_id` | | `null` | ARM resource ID of the Key Vault holding the master SP secret (required if `SRF_MASTER_CLIENT_SECRET` is not set) |
-| `master_keyvault_secret_name` | | `null` | Secret name inside that Key Vault (required if `SRF_MASTER_CLIENT_SECRET` is not set) |
+| `master_secret_name` | | `null` | Secret name inside that Key Vault (required if `SRF_MASTER_CLIENT_SECRET` is not set) |
 | `threshold_days` | | `7` | Rotate if expiry is within this many days |
 | `validity_days` | | `365` | New secret validity in days |
 | `master_owners` | | `[]` | User object IDs added as owner to every SP |
@@ -235,7 +235,7 @@ secrets:
 | `name` | ✅ | — | Display name (used in reports) |
 | `app_id` | ✅ | — | SP application (client) ID |
 | `keyvault_id` | ✅ | — | ARM resource ID of the Key Vault to store the rotated secret |
-| `keyvault_secret_name` | ✅ | — | Secret name to create/overwrite in that Key Vault |
+| `secret_name` | ✅ | — | Secret name to create/overwrite in that Key Vault |
 | `keyvault_secret_description` | | `null` | Stored as `content_type` on the KV secret |
 | `required_owners` | | `[]` | User object IDs added as owner for this SP only |
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -76,7 +76,7 @@
           "default": null,
           "title": "Master Keyvault Id"
         },
-        "master_keyvault_secret_name": {
+        "master_secret_name": {
           "anyOf": [
             {
               "type": "string"
@@ -133,7 +133,7 @@
           "title": "Keyvault Id",
           "type": "string"
         },
-        "keyvault_secret_name": {
+        "secret_name": {
           "title": "Keyvault Secret Name",
           "type": "string"
         },
@@ -192,7 +192,7 @@
         "name",
         "app_id",
         "keyvault_id",
-        "keyvault_secret_name"
+        "secret_name"
       ],
       "title": "SecretConfig",
       "type": "object"

--- a/input.yaml
+++ b/input.yaml
@@ -12,7 +12,7 @@ main:
   # --- Auth Mode 3: Key Vault bootstrap (managed identity only, NOT for GitHub Actions) ---
   # master_client_id: 422e63ed-df23-4bd0-98de-2a20762a7c7d
   # master_keyvault_id: /subscriptions/6801b1ff-7314-4480-8e4b-42f910440eb8/resourceGroups/master1/providers/Microsoft.KeyVault/vaults/kv-master1
-  # master_keyvault_secret_name: master-sp-client-secret
+  # master_secret_name: master-sp-client-secret
   threshold_days: 7
   validity_days: 365
   master_owners: # user object ID added to every SP
@@ -35,13 +35,13 @@ secrets:
   - name: slave1
     app_id: 6302d378-080d-4d83-b8eb-f894e6f75250
     keyvault_id: /subscriptions/6801b1ff-7314-4480-8e4b-42f910440eb8/resourceGroups/slave1/providers/Microsoft.KeyVault/vaults/kv-slave1
-    keyvault_secret_name: slave1-client-secret
+    secret_name: slave1-client-secret
     keyvault_secret_description: "Client secret for slave1 SP — managed by SRF rotation tool"
     threshold_days: 0   # override global threshold for this SP only
     validity_days: 180   # override global validity for this SP only
 
   - name: slave2
     app_id: 32e99f34-5731-4fa9-95ae-8115360b0701
-    keyvault_id: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.KeyVault/vaults/my-secrets-kv
-    keyvault_secret_name: slave2-client-secret
+    keyvault_id: /subscriptions/6801b1ff-7314-4480-8e4b-42f910440eb8/resourceGroups/slave2/providers/Microsoft.KeyVault/vaults/kv-slave2
+    secret_name: slave2-client-secret
     # keyvault_secret_description is optional — omit to leave KV content_type blank

--- a/main.py
+++ b/main.py
@@ -23,12 +23,15 @@ logger = logging.getLogger(__name__)
 def _make_kv_factory(credential):
     def factory(keyvault_id: str) -> KeyVaultClient:
         return KeyVaultClient(credential=credential, keyvault_id=keyvault_id)
+
     return factory
 
 
 def _print_summary(results: list[RotationResult], run_id: Optional[str] = None) -> None:
     rotated = [r for r in results if r.rotated]
-    skipped = [r for r in results if not r.rotated and r.error is None and not r.dry_run]
+    skipped = [
+        r for r in results if not r.rotated and r.error is None and not r.dry_run
+    ]
     dry_run_results = [r for r in results if r.dry_run]
     failed = [r for r in results if not r.rotated and r.error is not None]
 
@@ -36,7 +39,7 @@ def _print_summary(results: list[RotationResult], run_id: Optional[str] = None) 
     header = col.format("NAME", "APP ID", "STATUS", "EXPIRY", "DETAIL")
     sep = "-" * len(header)
 
-    print(f"\n{'='*len(header)}")
+    print(f"\n{'=' * len(header)}")
     print("Azure SP Secret Rotation — Summary")
     print(f"Run: {datetime.now(tz=timezone.utc).strftime('%Y-%m-%d %H:%M UTC')}")
     if run_id:
@@ -49,38 +52,59 @@ def _print_summary(results: list[RotationResult], run_id: Optional[str] = None) 
         detail = f"vault={r.keyvault_name}"
         if r.kv_secret_missing:
             detail += " (kv-secret-missing)"
-        print(col.format(r.name[:19], r.app_id, "✓ ROTATED", _fmt(r.new_expiry), detail))
+        print(
+            col.format(r.name[:19], r.app_id, "✓ ROTATED", _fmt(r.new_expiry), detail)
+        )
         for warning in r.cleanup_warnings:
             print(f"  ⚠ CLEANUP WARNING: {warning}")
     for r in skipped:
-        print(col.format(
-            r.name[:19], r.app_id,
-            "– SKIPPED",
-            _fmt(r.current_expiry),
-            "not expiring soon",
-        ))
+        print(
+            col.format(
+                r.name[:19],
+                r.app_id,
+                "– SKIPPED",
+                _fmt(r.current_expiry),
+                "not expiring soon",
+            )
+        )
     for r in dry_run_results:
         if r.rotation_needed or r.was_created:
             label = "WOULD CREATE" if r.was_created else "WOULD ROTATE"
-            reason = "kv-secret-missing" if r.kv_secret_missing else f"vault={r.keyvault_name}"
-            print(col.format(r.name[:19], r.app_id, f"~ {label}", _fmt(r.current_expiry), reason))
+            reason = (
+                "kv-secret-missing"
+                if r.kv_secret_missing
+                else f"vault={r.keyvault_name}"
+            )
+            print(
+                col.format(
+                    r.name[:19], r.app_id, f"~ {label}", _fmt(r.current_expiry), reason
+                )
+            )
         else:
-            print(col.format(
-                r.name[:19], r.app_id,
-                "– NO CHANGE",
-                _fmt(r.current_expiry),
-                "not expiring soon (dry-run)",
-            ))
+            print(
+                col.format(
+                    r.name[:19],
+                    r.app_id,
+                    "– NO CHANGE",
+                    _fmt(r.current_expiry),
+                    "not expiring soon (dry-run)",
+                )
+            )
     for r in failed:
-        print(col.format(
-            r.name[:19], r.app_id,
-            "✗ FAILED",
-            "",
-            (r.error or "")[:60],
-        ))
+        print(
+            col.format(
+                r.name[:19],
+                r.app_id,
+                "✗ FAILED",
+                "",
+                (r.error or "")[:60],
+            )
+        )
 
     print(sep)
-    print(f"Total: {len(results)}  |  Rotated: {len(rotated)}  |  Skipped: {len(skipped)}  |  Failed: {len(failed)}")
+    print(
+        f"Total: {len(results)}  |  Rotated: {len(rotated)}  |  Skipped: {len(skipped)}  |  Failed: {len(failed)}"
+    )
     print("=" * len(header))
 
 
@@ -96,24 +120,39 @@ def _print_ownership_summary(ownership_results: list[OwnershipResult]) -> None:
     header = col.format("NAME", "APP ID", "STATUS", "DETAIL")
     sep = "-" * len(header)
 
-    print(f"\n{'='*len(header)}")
+    print(f"\n{'=' * len(header)}")
     print("Azure SP Ownership — Summary")
     print(sep)
     print(header)
     print(sep)
 
     for r in skipped:
-        print(col.format(r.name[:19], r.app_id, "SKIPPED", "no required_owners configured"))
+        print(
+            col.format(
+                r.name[:19], r.app_id, "SKIPPED", "no required_owners configured"
+            )
+        )
     for r in checked:
         if r.dry_run:
             if r.owners_would_add:
-                print(col.format(r.name[:19], r.app_id, "~ WOULD UPDATE", f"would_add={r.owners_would_add}"))
+                print(
+                    col.format(
+                        r.name[:19],
+                        r.app_id,
+                        "~ WOULD UPDATE",
+                        f"would_add={r.owners_would_add}",
+                    )
+                )
             else:
                 print(col.format(r.name[:19], r.app_id, "– OK", "owners OK (dry-run)"))
         elif r.error:
             print(col.format(r.name[:19], r.app_id, "✗ FAILED", (r.error or "")[:60]))
         elif r.owners_added:
-            print(col.format(r.name[:19], r.app_id, "✓ UPDATED", f"added={r.owners_added}"))
+            print(
+                col.format(
+                    r.name[:19], r.app_id, "✓ UPDATED", f"added={r.owners_added}"
+                )
+            )
         else:
             print(col.format(r.name[:19], r.app_id, "– OK", f"all owners present"))
 
@@ -130,6 +169,7 @@ def _fmt(dt) -> str:
         return "N/A"
     if dt.tzinfo is None:
         from datetime import timezone as tz
+
         dt = dt.replace(tzinfo=tz.utc)
     return dt.strftime("%Y-%m-%d %H:%M UTC")
 
@@ -137,14 +177,21 @@ def _fmt(dt) -> str:
 def _print_decoded_run_id(run_id_str: str) -> int:
     """Decode and pretty-print a UUID v8 SRF run identifier."""
     from srf.run_id.service import RunIdService
+
     try:
         info = RunIdService.decode(run_id_str)
     except (ValueError, AttributeError) as exc:
-        print(f"Error: '{run_id_str}' is not a valid SRF run ID ({type(exc).__name__})", file=sys.stderr)
+        print(
+            f"Error: '{run_id_str}' is not a valid SRF run ID ({type(exc).__name__})",
+            file=sys.stderr,
+        )
         return 1
 
     if info.version != 8:
-        print(f"Warning: UUID version is {info.version}, expected 8. Results may be incorrect.", file=sys.stderr)
+        print(
+            f"Warning: UUID version is {info.version}, expected 8. Results may be incorrect.",
+            file=sys.stderr,
+        )
 
     gha_run_url = (
         f"  github_run_url : https://github.com/<owner>/<repo>/actions/runs/{info.github_run_id}"
@@ -152,17 +199,19 @@ def _print_decoded_run_id(run_id_str: str) -> int:
         else ""
     )
 
-    print(f"""
+    print(
+        f"""
 SRF Run ID Decoder
 ══════════════════════════════════════════════════
   run_id         : {run_id_str}
   version        : {info.version}
   timestamp_ms   : {info.timestamp_ms}
-  datetime_utc   : {info.datetime_utc.strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]} UTC
+  datetime_utc   : {info.datetime_utc.strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]} UTC
   origin         : {info.origin}
   event          : {info.event}
-  github_run_id  : {info.github_run_id if info.github_run_id is not None else 'N/A (CLI run)'}
-{gha_run_url}══════════════════════════════════════════════════""".strip())
+  github_run_id  : {info.github_run_id if info.github_run_id is not None else "N/A (CLI run)"}
+{gha_run_url}══════════════════════════════════════════════════""".strip()
+    )
     return 0
 
 
@@ -175,28 +224,66 @@ def main() -> int:
         "decode",
         help="Decode a UUID v8 SRF run identifier and print its fields",
     )
-    decode_parser.add_argument("run_id", metavar="RUN_ID", help="UUID v8 run ID to decode")
+    decode_parser.add_argument(
+        "run_id", metavar="RUN_ID", help="UUID v8 run ID to decode"
+    )
 
     # ── rotate subcommand (default when no subcommand given) ───────────────────
     rotate_parser = subparsers.add_parser(
         "rotate",
         help="Rotate Azure SP client secrets (default when no subcommand is given)",
     )
-    rotate_parser.add_argument("--config", default="input.yaml", help="Path to YAML config (default: input.yaml)")
-    rotate_parser.add_argument("--workers", type=int, default=5, help="Max parallel workers (default: 5)")
-    rotate_parser.add_argument("--threshold-days", type=int, default=None, help="Days before expiry to trigger rotation (default: 7)")
-    rotate_parser.add_argument("--validity-days", type=int, default=None, help="Validity of new secrets in days (default: 365)")
-    rotate_parser.add_argument("--dry-run", action="store_true", help="Show what would change without making any writes")
-    rotate_parser.add_argument("--no-mail", action="store_true", help="Suppress email report even if mail config is present")
-    rotate_parser.add_argument("--validate", action="store_true", help="Validate input YAML against config.schema.json and exit")
-    rotate_parser.add_argument("--debug", action="store_true", help="Enable debug logging for SRF modules (overrides SRF_LOG_LEVEL)")
+    rotate_parser.add_argument(
+        "--config",
+        default="input.yaml",
+        help="Path to YAML config (default: input.yaml)",
+    )
+    rotate_parser.add_argument(
+        "--workers", type=int, default=5, help="Max parallel workers (default: 5)"
+    )
+    rotate_parser.add_argument(
+        "--threshold-days",
+        type=int,
+        default=None,
+        help="Days before expiry to trigger rotation (default: 7)",
+    )
+    rotate_parser.add_argument(
+        "--validity-days",
+        type=int,
+        default=None,
+        help="Validity of new secrets in days (default: 365)",
+    )
+    rotate_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would change without making any writes",
+    )
+    rotate_parser.add_argument(
+        "--no-mail",
+        action="store_true",
+        help="Suppress email report even if mail config is present",
+    )
+    rotate_parser.add_argument(
+        "--validate",
+        action="store_true",
+        help="Validate input YAML against config.schema.json and exit",
+    )
+    rotate_parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Enable debug logging for SRF modules (overrides SRF_LOG_LEVEL)",
+    )
 
     # Re-attach rotate flags to the top-level parser so that bare `main.py`
     # (no subcommand) still works — this preserves backwards compatibility.
     parser.add_argument("--config", default="input.yaml", help=argparse.SUPPRESS)
     parser.add_argument("--workers", type=int, default=5, help=argparse.SUPPRESS)
-    parser.add_argument("--threshold-days", type=int, default=None, help=argparse.SUPPRESS)
-    parser.add_argument("--validity-days", type=int, default=None, help=argparse.SUPPRESS)
+    parser.add_argument(
+        "--threshold-days", type=int, default=None, help=argparse.SUPPRESS
+    )
+    parser.add_argument(
+        "--validity-days", type=int, default=None, help=argparse.SUPPRESS
+    )
     parser.add_argument("--dry-run", action="store_true", help=argparse.SUPPRESS)
     parser.add_argument("--no-mail", action="store_true", help=argparse.SUPPRESS)
     parser.add_argument("--validate", action="store_true", help=argparse.SUPPRESS)
@@ -218,7 +305,10 @@ def main() -> int:
     else:
         env_level = os.environ.get(_ENV_LOG_LEVEL, "").upper()
         if env_level and env_level not in _VALID_LEVELS:
-            print(f"WARNING: invalid {_ENV_LOG_LEVEL}={env_level!r}, expected one of {sorted(_VALID_LEVELS)}. Defaulting to WARNING.", file=sys.stderr)
+            print(
+                f"WARNING: invalid {_ENV_LOG_LEVEL}={env_level!r}, expected one of {sorted(_VALID_LEVELS)}. Defaulting to WARNING.",
+                file=sys.stderr,
+            )
             env_level = ""
         log_level = getattr(logging, env_level) if env_level else logging.WARNING
     logging.basicConfig(
@@ -235,6 +325,7 @@ def main() -> int:
 
         import jsonschema
         import yaml as _yaml
+
         schema_path = pathlib.Path(__file__).parent / "config.schema.json"
         schema = json.loads(schema_path.read_text())
         raw = _yaml.safe_load(open(args.config))
@@ -247,18 +338,40 @@ def main() -> int:
         sys.exit(0)
 
     config = load_config(args.config)
-    logger.info("Config loaded from %s — %d SP(s) configured", args.config, len(config.secrets))
+    logger.info(
+        "Config loaded from %s — %d SP(s) configured", args.config, len(config.secrets)
+    )
 
     run_id_svc = RunIdService()
-    print(f"Run ID: {run_id_svc.run_id}  origin={run_id_svc.origin}  event={run_id_svc.event}")
-    logger.debug("run_id=%s origin=%s event=%s", run_id_svc.run_id, run_id_svc.origin, run_id_svc.event)
+    print(
+        f"Run ID: {run_id_svc.run_id}  origin={run_id_svc.origin}  event={run_id_svc.event}"
+    )
+    logger.debug(
+        "run_id=%s origin=%s event=%s",
+        run_id_svc.run_id,
+        run_id_svc.origin,
+        run_id_svc.event,
+    )
 
-    threshold = args.threshold_days if args.threshold_days is not None else config.main.threshold_days
-    validity = args.validity_days if args.validity_days is not None else config.main.validity_days
+    threshold = (
+        args.threshold_days
+        if args.threshold_days is not None
+        else config.main.threshold_days
+    )
+    validity = (
+        args.validity_days
+        if args.validity_days is not None
+        else config.main.validity_days
+    )
 
     auth = AuthProvider(config.main)
     master_credential = auth.get_master_credential()
-    logger.info("Starting rotation run: dry_run=%s, threshold_days=%s, validity_days=%s", args.dry_run, threshold, validity)
+    logger.info(
+        "Starting rotation run: dry_run=%s, threshold_days=%s, validity_days=%s",
+        args.dry_run,
+        threshold,
+        validity,
+    )
 
     graph = GraphClient(credential=master_credential)
     kv_factory = _make_kv_factory(master_credential)
@@ -271,8 +384,14 @@ def main() -> int:
         dry_run=args.dry_run,
         run_id=run_id_svc.run_id,
     )
-    ownership_checker = OwnershipChecker(graph_client=graph, master_owners=config.main.master_owners, dry_run=args.dry_run)
-    runner = ParallelRunner(rotator=rotator, ownership_checker=ownership_checker, max_workers=args.workers)
+    ownership_checker = OwnershipChecker(
+        graph_client=graph,
+        master_owners=config.main.master_owners,
+        dry_run=args.dry_run,
+    )
+    runner = ParallelRunner(
+        rotator=rotator, ownership_checker=ownership_checker, max_workers=args.workers
+    )
     rotation_results, ownership_results = runner.run(config.secrets)
 
     _print_summary(rotation_results, run_id=run_id_svc.run_id)
@@ -288,7 +407,9 @@ def main() -> int:
             reporter.send_report(rotation_results)
             print("Email sent.")
         except Exception as exc:
-            print(f"WARNING: email report failed ({type(exc).__name__}) — rotation results above are complete.")
+            print(
+                f"WARNING: email report failed ({type(exc).__name__}) — rotation results above are complete."
+            )
 
     failed_count = sum(1 for r in rotation_results if r.error)
     ownership_failed_count = sum(1 for r in ownership_results if r.error)

--- a/srf/auth/provider.py
+++ b/srf/auth/provider.py
@@ -31,7 +31,7 @@ class AuthProvider:
         ``master_client_id`` in YAML is optional — ``AZURE_CLIENT_ID`` env var is used instead.
 
     **Mode 3 — Key Vault bootstrap** (for environments with a pre-existing managed identity)
-        Provide ``master_keyvault_id`` + ``master_keyvault_secret_name`` in the YAML.
+        Provide ``master_keyvault_id`` + ``master_secret_name`` in the YAML.
         ``DefaultAzureCredential`` reads the master SP secret from that Key Vault, then
         creates a ``ClientSecretCredential``.  Only use when the *host* already has an
         identity (Managed Identity, ``az login``) that can reach the Key Vault — otherwise
@@ -51,7 +51,11 @@ class AuthProvider:
                 raise RuntimeError(
                     f"{_ENV_VAR!r} is set but 'master_client_id' is missing from the YAML config."
                 )
-            logger.info("Auth mode 1: ClientSecretCredential via %s env var (client_id=%s)", _ENV_VAR, self._config.master_client_id)
+            logger.info(
+                "Auth mode 1: ClientSecretCredential via %s env var (client_id=%s)",
+                _ENV_VAR,
+                self._config.master_client_id,
+            )
             return ClientSecretCredential(
                 tenant_id=self._config.tenant_id,
                 client_id=self._config.master_client_id,
@@ -61,18 +65,22 @@ class AuthProvider:
         # ------------------------------------------------------------------ #
         # Mode 3: Key Vault bootstrap (requires host identity for KV access)  #
         # ------------------------------------------------------------------ #
-        if self._config.master_keyvault_id and self._config.master_keyvault_secret_name:
+        if self._config.master_keyvault_id and self._config.master_secret_name:
             if not self._config.master_client_id:
                 raise RuntimeError(
                     "Key Vault bootstrap requires 'master_client_id' in the YAML config."
                 )
-            logger.info("Auth mode 3: Key Vault bootstrap (keyvault=%s, client_id=%s)", self._config.master_keyvault_id, self._config.master_client_id)
+            logger.info(
+                "Auth mode 3: Key Vault bootstrap (keyvault=%s, client_id=%s)",
+                self._config.master_keyvault_id,
+                self._config.master_client_id,
+            )
             bootstrap_credential = DefaultAzureCredential()
             kv = KeyVaultClient(
                 credential=bootstrap_credential,
                 keyvault_id=self._config.master_keyvault_id,
             )
-            kv_secret = kv.get_secret(self._config.master_keyvault_secret_name)
+            kv_secret = kv.get_secret(self._config.master_secret_name)
             return ClientSecretCredential(
                 tenant_id=self._config.tenant_id,
                 client_id=self._config.master_client_id,
@@ -87,6 +95,7 @@ class AuthProvider:
         #   - Local: az login session
         #   - Azure compute: Managed Identity
         # No client secret is required; Azure handles token exchange.
-        logger.info("Auth mode 2: DefaultAzureCredential (OIDC / az login / Managed Identity)")
+        logger.info(
+            "Auth mode 2: DefaultAzureCredential (OIDC / az login / Managed Identity)"
+        )
         return DefaultAzureCredential()
-

--- a/srf/config/models.py
+++ b/srf/config/models.py
@@ -12,7 +12,7 @@ class MainConfig(BaseModel):
     tenant_id: str
     master_client_id: Optional[str] = Field(default=None)
     master_keyvault_id: Optional[str] = Field(default=None)
-    master_keyvault_secret_name: Optional[str] = Field(default=None)
+    master_secret_name: Optional[str] = Field(default=None)
     threshold_days: int = Field(default=7, ge=0, le=365)
     validity_days: ValidityDays = Field(default=365)
     master_owners: list[str] = Field(default_factory=list)
@@ -41,7 +41,7 @@ class SecretConfig(BaseModel):
     name: str
     app_id: str
     keyvault_id: str
-    keyvault_secret_name: str
+    secret_name: str
     keyvault_secret_description: Optional[str] = Field(default=None)
     required_owners: list[str] = Field(default_factory=list)
     threshold_days: Optional[int] = Field(default=None, ge=0, le=365)

--- a/srf/keyvault/client.py
+++ b/srf/keyvault/client.py
@@ -56,7 +56,7 @@ class KeyVaultClient:
         name: str,
         value: str,
         description: str | None = None,
-        expires_on: datetime | None = None,
+        expires_on: datetime.datetime | None = None,
     ) -> None:
         logger.debug("set_secret vault=%s name=%s", self._vault_name, name)
         self._client.set_secret(

--- a/srf/keyvault/client.py
+++ b/srf/keyvault/client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime
 import logging
 import re
 
@@ -15,9 +16,13 @@ def parse_keyvault_uri(resource_id: str) -> str:
     Expected format:
     /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.KeyVault/vaults/{name}
     """
-    match = re.search(r"/providers/Microsoft\.KeyVault/vaults/([^/]+)$", resource_id, re.IGNORECASE)
+    match = re.search(
+        r"/providers/Microsoft\.KeyVault/vaults/([^/]+)$", resource_id, re.IGNORECASE
+    )
     if not match:
-        raise ValueError(f"Cannot parse Key Vault name from resource ID: {resource_id!r}")
+        raise ValueError(
+            f"Cannot parse Key Vault name from resource ID: {resource_id!r}"
+        )
     vault_name = match.group(1)
     return f"https://{vault_name}.vault.azure.net"
 
@@ -46,7 +51,15 @@ class KeyVaultClient:
         logger.info("get_secret OK vault=%s name=%s", self._vault_name, name)
         return value
 
-    def set_secret(self, name: str, value: str, description: str | None = None) -> None:
+    def set_secret(
+        self,
+        name: str,
+        value: str,
+        description: str | None = None,
+        expires_on: datetime | None = None,
+    ) -> None:
         logger.debug("set_secret vault=%s name=%s", self._vault_name, name)
-        self._client.set_secret(name, value, content_type=description)
+        self._client.set_secret(
+            name, value, content_type=description, expires_on=expires_on
+        )
         logger.info("set_secret OK vault=%s name=%s", self._vault_name, name)

--- a/srf/rotation/rotator.py
+++ b/srf/rotation/rotator.py
@@ -41,6 +41,7 @@ class SecretRotator:
         self,
         graph_client: GraphClient,
         keyvault_client_factory,
+        secret_name: Optional[str] = "Default Secret",
         threshold_days: int = 7,
         validity_days: int = 365,
         dry_run: bool = False,
@@ -55,19 +56,24 @@ class SecretRotator:
             validity_days: Validity period for newly created credentials.
             dry_run: If True, no writes are made; results reflect what would happen.
             run_id: UUID v8 run identifier used as the Azure AD credential display_name
-                prefix (``srf-<first_13_chars>``). When omitted, falls back to the
-                static string ``"rotated-by-srf"``.
+                prefix (``{secret_name}-<first_13_chars>``). When omitted, falls back to the
+                static string ``"{secret_name}"``.
         """
         self._graph = graph_client
         self._kv_factory = keyvault_client_factory
         self._threshold = timedelta(days=threshold_days)
         self._validity_days = validity_days
         self._dry_run = dry_run
-        self._display_name = f"srf-{run_id[:13]}" if run_id else "rotated-by-srf"
+        self._display_name = f"{secret_name}-{run_id}" if run_id else secret_name
+        self._run_id = run_id
 
     # ------------------------------------------------------------------
 
-    def needs_rotation(self, credentials: list[PasswordCredential], threshold: Optional[timedelta] = None) -> tuple[bool, Optional[datetime]]:
+    def needs_rotation(
+        self,
+        credentials: list[PasswordCredential],
+        threshold: Optional[timedelta] = None,
+    ) -> tuple[bool, Optional[datetime]]:
         """Return (needs_rotation, soonest_expiry) for the credential set.
 
         A threshold of zero is treated as "always rotate": rotation is forced
@@ -80,11 +86,19 @@ class SecretRotator:
         # threshold_days=0 means force rotation on every run
         if effective_threshold == timedelta(0):
             now = datetime.now(tz=timezone.utc)
-            soonest = min(
-                (c.end_date_time.replace(tzinfo=timezone.utc) if c.end_date_time and c.end_date_time.tzinfo is None else c.end_date_time)
-                for c in credentials
-                if c.end_date_time is not None
-            ) if any(c.end_date_time is not None for c in credentials) else None
+            soonest = (
+                min(
+                    (
+                        c.end_date_time.replace(tzinfo=timezone.utc)
+                        if c.end_date_time and c.end_date_time.tzinfo is None
+                        else c.end_date_time
+                    )
+                    for c in credentials
+                    if c.end_date_time is not None
+                )
+                if any(c.end_date_time is not None for c in credentials)
+                else None
+            )
             return True, soonest
 
         now = datetime.now(tz=timezone.utc)
@@ -121,31 +135,48 @@ class SecretRotator:
         )
         logger.info(
             "processing [%s] app_id=%s vault=%s threshold_days=%s validity_days=%s dry_run=%s",
-            secret_config.name, secret_config.app_id, vault_name,
-            int(eff_threshold.days), eff_validity, self._dry_run,
+            secret_config.name,
+            secret_config.app_id,
+            vault_name,
+            int(eff_threshold.days),
+            eff_validity,
+            self._dry_run,
         )
         try:
             credentials = self._graph.list_password_credentials(secret_config.app_id)
             was_created = len(credentials) == 0
-            should_rotate, current_expiry = self.needs_rotation(credentials, threshold=eff_threshold)
+            should_rotate, current_expiry = self.needs_rotation(
+                credentials, threshold=eff_threshold
+            )
             kv_secret_missing = False
             logger.debug(
                 "[%s] credentials=%d should_rotate=%s current_expiry=%s",
-                secret_config.name, len(credentials), should_rotate, current_expiry,
+                secret_config.name,
+                len(credentials),
+                should_rotate,
+                current_expiry,
             )
 
             if not should_rotate:
-                logger.debug("[%s] checking KV secret existence before skipping", secret_config.name)
+                logger.debug(
+                    "[%s] checking KV secret existence before skipping",
+                    secret_config.name,
+                )
                 kv = self._kv_factory(secret_config.keyvault_id)
-                if not kv.secret_exists(secret_config.keyvault_secret_name):
-                    logger.info("[%s] KV secret missing — forcing rotation despite valid SP credential", secret_config.name)
+                if not kv.secret_exists(secret_config.secret_name):
+                    logger.info(
+                        "[%s] KV secret missing — forcing rotation despite valid SP credential",
+                        secret_config.name,
+                    )
                     should_rotate = True
                     kv_secret_missing = True
                 else:
                     kv_secret_missing = False
 
             if not should_rotate:
-                logger.info("[%s] skipping — not expiring within threshold", secret_config.name)
+                logger.info(
+                    "[%s] skipping — not expiring within threshold", secret_config.name
+                )
                 if self._dry_run:
                     return RotationResult(
                         name=secret_config.name,
@@ -165,7 +196,12 @@ class SecretRotator:
                 )
 
             if self._dry_run:
-                logger.info("[%s] dry-run: would rotate (was_created=%s kv_secret_missing=%s)", secret_config.name, was_created, kv_secret_missing)
+                logger.info(
+                    "[%s] dry-run: would rotate (was_created=%s kv_secret_missing=%s)",
+                    secret_config.name,
+                    was_created,
+                    kv_secret_missing,
+                )
                 return RotationResult(
                     name=secret_config.name,
                     app_id=secret_config.app_id,
@@ -178,7 +214,12 @@ class SecretRotator:
                     kv_secret_missing=kv_secret_missing,
                 )
 
-            logger.info("[%s] rotating secret (was_created=%s kv_secret_missing=%s)", secret_config.name, was_created, kv_secret_missing)
+            logger.info(
+                "[%s] rotating secret (was_created=%s kv_secret_missing=%s)",
+                secret_config.name,
+                was_created,
+                kv_secret_missing,
+            )
             new_cred = self._graph.add_password_credential(
                 app_id=secret_config.app_id,
                 display_name=self._display_name,
@@ -188,15 +229,20 @@ class SecretRotator:
             logger.debug("[%s] writing new secret to Key Vault", secret_config.name)
             kv = self._kv_factory(secret_config.keyvault_id)
             kv.set_secret(
-                name=secret_config.keyvault_secret_name,
+                name=secret_config.secret_name,
                 value=new_cred.secret_text,  # type: ignore[arg-type]
-                description=secret_config.keyvault_secret_description,
+                description=f"{secret_config.keyvault_secret_description} - {self._run_id}",
+                expires_on=new_cred.end_date_time,
             )
 
             cleanup_warnings: list[str] = []
             for old_cred in credentials:
                 if old_cred.key_id and old_cred.key_id != new_cred.key_id:
-                    logger.debug("[%s] removing old credential key_id=%s", secret_config.name, old_cred.key_id)
+                    logger.debug(
+                        "[%s] removing old credential key_id=%s",
+                        secret_config.name,
+                        old_cred.key_id,
+                    )
                     try:
                         self._graph.remove_password_credential(
                             app_id=secret_config.app_id,
@@ -207,9 +253,18 @@ class SecretRotator:
                             f"Failed to remove old credential {old_cred.key_id}: "
                             f"{type(exc).__name__}"
                         )
-                        logger.warning("[%s] cleanup failed for key_id=%s: %s", secret_config.name, old_cred.key_id, type(exc).__name__)
+                        logger.warning(
+                            "[%s] cleanup failed for key_id=%s: %s",
+                            secret_config.name,
+                            old_cred.key_id,
+                            type(exc).__name__,
+                        )
 
-            logger.info("[%s] rotation complete new_expiry=%s", secret_config.name, new_cred.end_date_time)
+            logger.info(
+                "[%s] rotation complete new_expiry=%s",
+                secret_config.name,
+                new_cred.end_date_time,
+            )
             return RotationResult(
                 name=secret_config.name,
                 app_id=secret_config.app_id,
@@ -226,7 +281,11 @@ class SecretRotator:
             # Use only the exception type — never str(exc) for operations that
             # handle secrets. Azure SDK exceptions can embed request bodies,
             # tokens, or the new secret value in their message text.
-            logger.error("[%s] rotation failed: %s — check Azure logs for details", secret_config.name, type(exc).__name__)
+            logger.error(
+                "[%s] rotation failed: %s — check Azure logs for details",
+                secret_config.name,
+                type(exc).__name__,
+            )
             return RotationResult(
                 name=secret_config.name,
                 app_id=secret_config.app_id,

--- a/srf/run_id/service.py
+++ b/srf/run_id/service.py
@@ -148,11 +148,13 @@ class RunIdService:
         event_code  = (i >> 58) & 0x7
         run_id_raw  = (i >> 21) & 0x1FFFFFFFFF
 
+        origin = "github_actions" if origin_bit else "cli"
+        event  = _EVENT_NAMES.get(event_code, "other") if origin_bit else "cli"
         return RunIdInfo(
             version      = version,
             timestamp_ms = ts_ms,
             datetime_utc = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc),
-            origin       = "github_actions" if origin_bit else "cli",
-            event        = _EVENT_NAMES.get(event_code, "other"),
+            origin       = origin,
+            event        = event,
             github_run_id= run_id_raw if origin_bit else None,
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,11 @@ SP_KV_ID = (
 
 
 @pytest.fixture
+def run_id_svc():
+    return "run-id-svc-0001"
+
+
+@pytest.fixture
 def main_config():
     return MainConfig(
         tenant_id=TENANT_ID,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 """Shared pytest fixtures."""
+
 from __future__ import annotations
 
 import pytest
@@ -8,10 +9,14 @@ from srf.config.models import AppConfig, MainConfig, MailConfig, SecretConfig
 
 TENANT_ID = "tenant-0000"
 MASTER_CLIENT_ID = "master-0001"
-MASTER_KV_ID = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.KeyVault/vaults/master-kv"
+MASTER_KV_ID = (
+    "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.KeyVault/vaults/master-kv"
+)
 MASTER_KV_SECRET = "master-sp-client-secret"
 
-SP_KV_ID = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.KeyVault/vaults/sp-kv"
+SP_KV_ID = (
+    "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.KeyVault/vaults/sp-kv"
+)
 
 
 @pytest.fixture
@@ -20,7 +25,7 @@ def main_config():
         tenant_id=TENANT_ID,
         master_client_id=MASTER_CLIENT_ID,
         master_keyvault_id=MASTER_KV_ID,
-        master_keyvault_secret_name=MASTER_KV_SECRET,
+        master_secret_name=MASTER_KV_SECRET,
     )
 
 
@@ -43,7 +48,7 @@ def secret_config_with_description():
         name="slave1",
         app_id="app-0001",
         keyvault_id=SP_KV_ID,
-        keyvault_secret_name="slave1-secret",
+        secret_name="slave1-secret",
         keyvault_secret_description="My slave1 description",
     )
 
@@ -54,12 +59,17 @@ def secret_config_no_description():
         name="slave2",
         app_id="app-0002",
         keyvault_id=SP_KV_ID,
-        keyvault_secret_name="slave2-secret",
+        secret_name="slave2-secret",
     )
 
 
 @pytest.fixture
-def app_config(main_config, mail_config, secret_config_with_description, secret_config_no_description):
+def app_config(
+    main_config,
+    mail_config,
+    secret_config_with_description,
+    secret_config_no_description,
+):
     return AppConfig(
         main=main_config,
         mail=mail_config,

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -5,6 +5,7 @@ Covers all three resolution modes:
   2. Key Vault bootstrap → ClientSecretCredential (managed identity path)
   3. DefaultAzureCredential directly (OIDC / workload identity / az login path)
 """
+
 from __future__ import annotations
 
 import pytest
@@ -20,12 +21,13 @@ from srf.config.models import MainConfig
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _make_config(**overrides) -> MainConfig:
     defaults = dict(
         tenant_id="tenant-123",
         master_client_id="client-456",
         master_keyvault_id=None,
-        master_keyvault_secret_name=None,
+        secret_name=None,
     )
     defaults.update(overrides)
     return MainConfig(**defaults)
@@ -34,6 +36,7 @@ def _make_config(**overrides) -> MainConfig:
 # ---------------------------------------------------------------------------
 # Mode 1: env var path
 # ---------------------------------------------------------------------------
+
 
 def test_env_var_path_returns_credential(monkeypatch):
     monkeypatch.setenv("SRF_MASTER_CLIENT_SECRET", "my-env-secret")
@@ -57,11 +60,13 @@ def test_env_var_skips_keyvault(monkeypatch):
     monkeypatch.setenv("SRF_MASTER_CLIENT_SECRET", "secret-value")
     config = _make_config(
         master_keyvault_id="/subscriptions/sub/resourceGroups/rg/providers/Microsoft.KeyVault/vaults/kv",
-        master_keyvault_secret_name="my-secret",
+        master_secret_name="my-secret",
     )
 
-    with patch("srf.auth.provider.ClientSecretCredential") as mock_csc, \
-         patch("srf.auth.provider.KeyVaultClient") as mock_kv:
+    with (
+        patch("srf.auth.provider.ClientSecretCredential") as mock_csc,
+        patch("srf.auth.provider.KeyVaultClient") as mock_kv,
+    ):
         mock_csc.return_value = MagicMock()
         AuthProvider(config).get_master_credential()
 
@@ -73,11 +78,13 @@ def test_env_var_takes_precedence_over_kv(monkeypatch):
     monkeypatch.setenv("SRF_MASTER_CLIENT_SECRET", "env-wins")
     config = _make_config(
         master_keyvault_id="/subscriptions/sub/resourceGroups/rg/providers/Microsoft.KeyVault/vaults/kv",
-        master_keyvault_secret_name="kv-secret",
+        master_secret_name="kv-secret",
     )
 
-    with patch("srf.auth.provider.ClientSecretCredential") as mock_csc, \
-         patch("srf.auth.provider.KeyVaultClient"):
+    with (
+        patch("srf.auth.provider.ClientSecretCredential") as mock_csc,
+        patch("srf.auth.provider.KeyVaultClient"),
+    ):
         mock_csc.return_value = MagicMock()
         AuthProvider(config).get_master_credential()
 
@@ -98,16 +105,19 @@ def test_env_var_without_master_client_id_raises(monkeypatch):
 # Mode 3: Key Vault bootstrap path
 # ---------------------------------------------------------------------------
 
+
 def test_kv_path_reads_secret_and_returns_credential(monkeypatch):
     monkeypatch.delenv("SRF_MASTER_CLIENT_SECRET", raising=False)
     config = _make_config(
         master_keyvault_id="/subscriptions/sub/resourceGroups/rg/providers/Microsoft.KeyVault/vaults/my-kv",
-        master_keyvault_secret_name="master-secret",
+        master_secret_name="master-secret",
     )
 
-    with patch("srf.auth.provider.DefaultAzureCredential") as mock_dac, \
-         patch("srf.auth.provider.KeyVaultClient") as mock_kv_cls, \
-         patch("srf.auth.provider.ClientSecretCredential") as mock_csc:
+    with (
+        patch("srf.auth.provider.DefaultAzureCredential") as mock_dac,
+        patch("srf.auth.provider.KeyVaultClient") as mock_kv_cls,
+        patch("srf.auth.provider.ClientSecretCredential") as mock_csc,
+    ):
         mock_dac.return_value = MagicMock()
         mock_kv_instance = MagicMock()
         mock_kv_instance.get_secret.return_value = "kv-secret-value"
@@ -129,15 +139,19 @@ def test_kv_path_reads_secret_and_returns_credential(monkeypatch):
 
 def test_kv_path_uses_correct_kv_id(monkeypatch):
     monkeypatch.delenv("SRF_MASTER_CLIENT_SECRET", raising=False)
-    kv_id = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.KeyVault/vaults/my-kv"
+    kv_id = (
+        "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.KeyVault/vaults/my-kv"
+    )
     config = _make_config(
         master_keyvault_id=kv_id,
-        master_keyvault_secret_name="s",
+        master_secret_name="s",
     )
 
-    with patch("srf.auth.provider.DefaultAzureCredential"), \
-         patch("srf.auth.provider.KeyVaultClient") as mock_kv_cls, \
-         patch("srf.auth.provider.ClientSecretCredential"):
+    with (
+        patch("srf.auth.provider.DefaultAzureCredential"),
+        patch("srf.auth.provider.KeyVaultClient") as mock_kv_cls,
+        patch("srf.auth.provider.ClientSecretCredential"),
+    ):
         mock_kv_cls.return_value = MagicMock()
         mock_kv_cls.return_value.get_secret.return_value = "x"
         AuthProvider(config).get_master_credential()
@@ -152,7 +166,7 @@ def test_kv_path_without_master_client_id_raises(monkeypatch):
     config = _make_config(
         master_client_id=None,
         master_keyvault_id="/subscriptions/sub/resourceGroups/rg/providers/Microsoft.KeyVault/vaults/kv",
-        master_keyvault_secret_name="s",
+        master_secret_name="s",
     )
 
     with pytest.raises(RuntimeError, match="master_client_id"):
@@ -162,6 +176,7 @@ def test_kv_path_without_master_client_id_raises(monkeypatch):
 # ---------------------------------------------------------------------------
 # Mode 2: DefaultAzureCredential direct path (OIDC / Workload Identity)
 # ---------------------------------------------------------------------------
+
 
 def test_oidc_path_returns_default_azure_credential(monkeypatch):
     """When neither env var nor KV fields are set, DefaultAzureCredential is returned."""
@@ -182,9 +197,11 @@ def test_oidc_path_does_not_call_kv_or_csc(monkeypatch):
     monkeypatch.delenv("SRF_MASTER_CLIENT_SECRET", raising=False)
     config = MainConfig(tenant_id="tenant-123")
 
-    with patch("srf.auth.provider.DefaultAzureCredential") as mock_dac, \
-         patch("srf.auth.provider.KeyVaultClient") as mock_kv, \
-         patch("srf.auth.provider.ClientSecretCredential") as mock_csc:
+    with (
+        patch("srf.auth.provider.DefaultAzureCredential") as mock_dac,
+        patch("srf.auth.provider.KeyVaultClient") as mock_kv,
+        patch("srf.auth.provider.ClientSecretCredential") as mock_csc,
+    ):
         mock_dac.return_value = MagicMock()
         AuthProvider(config).get_master_credential()
 
@@ -192,10 +209,10 @@ def test_oidc_path_does_not_call_kv_or_csc(monkeypatch):
     mock_csc.assert_not_called()
 
 
-
 # ---------------------------------------------------------------------------
 # Env var path
 # ---------------------------------------------------------------------------
+
 
 def test_env_var_path_returns_credential(monkeypatch):
     monkeypatch.setenv("SRF_MASTER_CLIENT_SECRET", "my-env-secret")
@@ -219,11 +236,13 @@ def test_env_var_skips_keyvault(monkeypatch):
     monkeypatch.setenv("SRF_MASTER_CLIENT_SECRET", "secret-value")
     config = _make_config(
         master_keyvault_id="/subscriptions/sub/resourceGroups/rg/providers/Microsoft.KeyVault/vaults/kv",
-        master_keyvault_secret_name="my-secret",
+        master_secret_name="my-secret",
     )
 
-    with patch("srf.auth.provider.ClientSecretCredential") as mock_csc, \
-         patch("srf.auth.provider.KeyVaultClient") as mock_kv:
+    with (
+        patch("srf.auth.provider.ClientSecretCredential") as mock_csc,
+        patch("srf.auth.provider.KeyVaultClient") as mock_kv,
+    ):
         mock_csc.return_value = MagicMock()
         AuthProvider(config).get_master_credential()
 
@@ -235,11 +254,13 @@ def test_env_var_takes_precedence_over_kv(monkeypatch):
     monkeypatch.setenv("SRF_MASTER_CLIENT_SECRET", "env-wins")
     config = _make_config(
         master_keyvault_id="/subscriptions/sub/resourceGroups/rg/providers/Microsoft.KeyVault/vaults/kv",
-        master_keyvault_secret_name="kv-secret",
+        master_secret_name="kv-secret",
     )
 
-    with patch("srf.auth.provider.ClientSecretCredential") as mock_csc, \
-         patch("srf.auth.provider.KeyVaultClient"):
+    with (
+        patch("srf.auth.provider.ClientSecretCredential") as mock_csc,
+        patch("srf.auth.provider.KeyVaultClient"),
+    ):
         mock_csc.return_value = MagicMock()
         AuthProvider(config).get_master_credential()
 
@@ -252,16 +273,19 @@ def test_env_var_takes_precedence_over_kv(monkeypatch):
 # Key Vault path
 # ---------------------------------------------------------------------------
 
+
 def test_kv_path_reads_secret_and_returns_credential(monkeypatch):
     monkeypatch.delenv("SRF_MASTER_CLIENT_SECRET", raising=False)
     config = _make_config(
         master_keyvault_id="/subscriptions/sub/resourceGroups/rg/providers/Microsoft.KeyVault/vaults/my-kv",
-        master_keyvault_secret_name="master-secret",
+        master_secret_name="master-secret",
     )
 
-    with patch("srf.auth.provider.DefaultAzureCredential") as mock_dac, \
-         patch("srf.auth.provider.KeyVaultClient") as mock_kv_cls, \
-         patch("srf.auth.provider.ClientSecretCredential") as mock_csc:
+    with (
+        patch("srf.auth.provider.DefaultAzureCredential") as mock_dac,
+        patch("srf.auth.provider.KeyVaultClient") as mock_kv_cls,
+        patch("srf.auth.provider.ClientSecretCredential") as mock_csc,
+    ):
         mock_dac.return_value = MagicMock()
         mock_kv_instance = MagicMock()
         mock_kv_instance.get_secret.return_value = "kv-secret-value"
@@ -283,15 +307,19 @@ def test_kv_path_reads_secret_and_returns_credential(monkeypatch):
 
 def test_kv_path_uses_correct_kv_id(monkeypatch):
     monkeypatch.delenv("SRF_MASTER_CLIENT_SECRET", raising=False)
-    kv_id = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.KeyVault/vaults/my-kv"
+    kv_id = (
+        "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.KeyVault/vaults/my-kv"
+    )
     config = _make_config(
         master_keyvault_id=kv_id,
-        master_keyvault_secret_name="s",
+        master_secret_name="s",
     )
 
-    with patch("srf.auth.provider.DefaultAzureCredential"), \
-         patch("srf.auth.provider.KeyVaultClient") as mock_kv_cls, \
-         patch("srf.auth.provider.ClientSecretCredential"):
+    with (
+        patch("srf.auth.provider.DefaultAzureCredential"),
+        patch("srf.auth.provider.KeyVaultClient") as mock_kv_cls,
+        patch("srf.auth.provider.ClientSecretCredential"),
+    ):
         mock_kv_cls.return_value = MagicMock()
         mock_kv_cls.return_value.get_secret.return_value = "x"
         AuthProvider(config).get_master_credential()
@@ -304,18 +332,21 @@ def test_kv_path_uses_correct_kv_id(monkeypatch):
 # Partial config falls through to OIDC mode
 # ---------------------------------------------------------------------------
 
+
 def test_partial_kv_config_falls_through_to_oidc(monkeypatch):
     """Only master_keyvault_id without secret_name → KV fields incomplete →
     falls through to DefaultAzureCredential (OIDC mode)."""
     monkeypatch.delenv("SRF_MASTER_CLIENT_SECRET", raising=False)
     config = _make_config(
         master_keyvault_id="/subscriptions/sub/resourceGroups/rg/providers/Microsoft.KeyVault/vaults/kv",
-        # master_keyvault_secret_name intentionally omitted
+        # master_secret_name intentionally omitted
     )
 
-    with patch("srf.auth.provider.DefaultAzureCredential") as mock_dac, \
-         patch("srf.auth.provider.KeyVaultClient") as mock_kv, \
-         patch("srf.auth.provider.ClientSecretCredential") as mock_csc:
+    with (
+        patch("srf.auth.provider.DefaultAzureCredential") as mock_dac,
+        patch("srf.auth.provider.KeyVaultClient") as mock_kv,
+        patch("srf.auth.provider.ClientSecretCredential") as mock_csc,
+    ):
         mock_dac.return_value = MagicMock()
         AuthProvider(config).get_master_credential()
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,5 @@
 """Tests for YAML loading and Pydantic config models."""
+
 from __future__ import annotations
 
 import textwrap
@@ -13,12 +14,12 @@ MINIMAL_YAML = textwrap.dedent("""\
       tenant_id: tid
       master_client_id: cid
       master_keyvault_id: /subscriptions/s/resourceGroups/r/providers/Microsoft.KeyVault/vaults/kv
-      master_keyvault_secret_name: sec
+      master_secret_name: sec
     secrets:
       - name: sp1
         app_id: app-001
         keyvault_id: /subscriptions/s/resourceGroups/r/providers/Microsoft.KeyVault/vaults/sp-kv
-        keyvault_secret_name: sp1-secret
+        secret_name: sp1-secret
 """)
 
 FULL_YAML = textwrap.dedent("""\
@@ -26,7 +27,7 @@ FULL_YAML = textwrap.dedent("""\
       tenant_id: tid
       master_client_id: cid
       master_keyvault_id: /subscriptions/s/resourceGroups/r/providers/Microsoft.KeyVault/vaults/kv
-      master_keyvault_secret_name: sec
+      master_secret_name: sec
     mail:
       smtp_host: smtp.host
       smtp_port: 465
@@ -40,7 +41,7 @@ FULL_YAML = textwrap.dedent("""\
       - name: sp1
         app_id: app-001
         keyvault_id: /subscriptions/s/resourceGroups/r/providers/Microsoft.KeyVault/vaults/sp-kv
-        keyvault_secret_name: sp1-secret
+        secret_name: sp1-secret
         keyvault_secret_description: "A description"
 """)
 
@@ -100,14 +101,14 @@ def test_threshold_validity_explicit(tmp_path):
           tenant_id: tid
           master_client_id: cid
           master_keyvault_id: /subscriptions/s/resourceGroups/r/providers/Microsoft.KeyVault/vaults/kv
-          master_keyvault_secret_name: sec
+          master_secret_name: sec
           threshold_days: 14
           validity_days: 180
         secrets:
           - name: sp1
             app_id: app-001
             keyvault_id: /subscriptions/s/resourceGroups/r/providers/Microsoft.KeyVault/vaults/sp-kv
-            keyvault_secret_name: sp1-secret
+            secret_name: sp1-secret
     """)
     cfg_file = tmp_path / "cfg.yaml"
     cfg_file.write_text(yaml_text)
@@ -120,6 +121,7 @@ def test_threshold_validity_explicit(tmp_path):
 
 def test_default_smtp_port(mail_config):
     from srf.config.models import MailConfig
+
     m = MailConfig(
         smtp_host="h",
         smtp_user="u",
@@ -137,7 +139,7 @@ def test_validity_days_must_exceed_threshold(tmp_path):
           tenant_id: tid
           master_client_id: cid
           master_keyvault_id: /subscriptions/s/resourceGroups/r/providers/Microsoft.KeyVault/vaults/kv
-          master_keyvault_secret_name: sec
+          master_secret_name: sec
           threshold_days: 30
           validity_days: 30
         secrets: []
@@ -155,7 +157,7 @@ def test_threshold_days_negative_raises(tmp_path):
           tenant_id: tid
           master_client_id: cid
           master_keyvault_id: /subscriptions/s/resourceGroups/r/providers/Microsoft.KeyVault/vaults/kv
-          master_keyvault_secret_name: sec
+          master_secret_name: sec
           threshold_days: -1
         secrets: []
     """)
@@ -172,7 +174,7 @@ def test_validity_days_invalid_value_raises(tmp_path):
           tenant_id: tid
           master_client_id: cid
           master_keyvault_id: /subscriptions/s/resourceGroups/r/providers/Microsoft.KeyVault/vaults/kv
-          master_keyvault_secret_name: sec
+          master_secret_name: sec
           validity_days: 200
         secrets: []
     """)
@@ -198,7 +200,7 @@ def test_master_owners_from_yaml(tmp_path):
           tenant_id: tid
           master_client_id: cid
           master_keyvault_id: /subscriptions/s/resourceGroups/r/providers/Microsoft.KeyVault/vaults/kv
-          master_keyvault_secret_name: sec
+          master_secret_name: sec
           master_owners:
             - 00000000-0000-0000-0000-000000000001
             - 00000000-0000-0000-0000-000000000002
@@ -206,7 +208,7 @@ def test_master_owners_from_yaml(tmp_path):
           - name: sp1
             app_id: app-001
             keyvault_id: /subscriptions/s/resourceGroups/r/providers/Microsoft.KeyVault/vaults/sp-kv
-            keyvault_secret_name: sp1-secret
+            secret_name: sp1-secret
     """)
     cfg_file = tmp_path / "cfg.yaml"
     cfg_file.write_text(yaml_text)
@@ -227,7 +229,7 @@ def test_per_secret_threshold_and_validity_days(tmp_path):
           - name: sp1
             app_id: app-001
             keyvault_id: /subscriptions/s/resourceGroups/r/providers/Microsoft.KeyVault/vaults/sp-kv
-            keyvault_secret_name: sp1-secret
+            secret_name: sp1-secret
             threshold_days: 30
             validity_days: 180
     """)
@@ -258,7 +260,7 @@ def test_per_secret_validity_must_exceed_threshold(tmp_path):
           - name: sp1
             app_id: app-001
             keyvault_id: /subscriptions/s/resourceGroups/r/providers/Microsoft.KeyVault/vaults/sp-kv
-            keyvault_secret_name: sp1-secret
+            secret_name: sp1-secret
             threshold_days: 60
             validity_days: 60
     """)

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -2,6 +2,7 @@
 
 All Azure SDK calls are monkeypatched; no subprocess, no real network traffic.
 """
+
 from __future__ import annotations
 
 import sys
@@ -21,14 +22,14 @@ main:
   tenant_id: "tenant-abc"
   master_client_id: "master-app-id"
   master_keyvault_id: "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.KeyVault/vaults/myvault"
-  master_keyvault_secret_name: "master-secret"
+  master_secret_name: "master-secret"
   threshold_days: 7
   validity_days: 365
 secrets:
   - name: "sp-test"
     app_id: "app-id-123"
     keyvault_id: "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.KeyVault/vaults/myvault"
-    keyvault_secret_name: "sp-test-secret"
+    secret_name: "sp-test-secret"
 """
 
 # YAML without KV fields — relies on SRF_MASTER_CLIENT_SECRET env var
@@ -42,7 +43,7 @@ secrets:
   - name: "sp-test"
     app_id: "app-id-123"
     keyvault_id: "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.KeyVault/vaults/myvault"
-    keyvault_secret_name: "sp-test-secret"
+    secret_name: "sp-test-secret"
 """
 
 # mail block using exact Pydantic field names from MailConfig
@@ -63,18 +64,19 @@ main:
   tenant_x: "bad"
   master_client_id: "master-app-id"
   master_keyvault_id: "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.KeyVault/vaults/myvault"
-  master_keyvault_secret_name: "master-secret"
+  master_secret_name: "master-secret"
 secrets:
   - name: "sp-test"
     app_id: "app-id-123"
     keyvault_id: "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.KeyVault/vaults/myvault"
-    keyvault_secret_name: "sp-test-secret"
+    secret_name: "sp-test-secret"
 """
 
 
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture
 def minimal_yaml(tmp_path):
@@ -132,7 +134,9 @@ def mock_azure(monkeypatch):
         "srf.graph.client.GraphClient.list_password_credentials",
         lambda self, app_id: [mock_cred],
     )
-    monkeypatch.setattr("srf.graph.client.GraphClient.add_password_credential", add_password)
+    monkeypatch.setattr(
+        "srf.graph.client.GraphClient.add_password_credential", add_password
+    )
     monkeypatch.setattr(
         "srf.graph.client.GraphClient.remove_password_credential",
         lambda self, *a, **kw: None,
@@ -167,6 +171,7 @@ def mock_azure(monkeypatch):
 # Tests — --validate flag
 # ---------------------------------------------------------------------------
 
+
 def test_validate_valid_config(tmp_path, monkeypatch, capsys):
     p = tmp_path / "valid.yaml"
     p.write_text(_BASE_YAML)
@@ -191,8 +196,11 @@ def test_validate_invalid_config(tmp_path, monkeypatch, capsys):
 # Tests — --dry-run flag
 # ---------------------------------------------------------------------------
 
+
 def test_dry_run_no_writes(minimal_yaml, mock_azure, monkeypatch, capsys):
-    monkeypatch.setattr(sys, "argv", ["srf", "--config", str(minimal_yaml), "--dry-run"])
+    monkeypatch.setattr(
+        sys, "argv", ["srf", "--config", str(minimal_yaml), "--dry-run"]
+    )
     main.main()
     assert not mock_azure["add_password_credential"].called
     assert not mock_azure["set_secret"].called
@@ -201,7 +209,9 @@ def test_dry_run_no_writes(minimal_yaml, mock_azure, monkeypatch, capsys):
 
 
 def test_dry_run_output_contains_summary(minimal_yaml, mock_azure, monkeypatch, capsys):
-    monkeypatch.setattr(sys, "argv", ["srf", "--config", str(minimal_yaml), "--dry-run"])
+    monkeypatch.setattr(
+        sys, "argv", ["srf", "--config", str(minimal_yaml), "--dry-run"]
+    )
     main.main()
     out = capsys.readouterr().out
     assert "~ WOULD" in out or "NO CHANGE" in out
@@ -211,8 +221,11 @@ def test_dry_run_output_contains_summary(minimal_yaml, mock_azure, monkeypatch, 
 # Tests — --no-mail flag
 # ---------------------------------------------------------------------------
 
+
 def test_no_mail_suppresses_send(yaml_with_mail, mock_azure, monkeypatch):
-    monkeypatch.setattr(sys, "argv", ["srf", "--config", str(yaml_with_mail), "--no-mail"])
+    monkeypatch.setattr(
+        sys, "argv", ["srf", "--config", str(yaml_with_mail), "--no-mail"]
+    )
     main.main()
     assert not mock_azure["send_report"].called
 
@@ -227,9 +240,11 @@ def test_mail_sent_without_no_mail(yaml_with_mail, mock_azure, monkeypatch):
 # Tests — combined flags
 # ---------------------------------------------------------------------------
 
+
 def test_dry_run_and_no_mail_combined(yaml_with_mail, mock_azure, monkeypatch):
     monkeypatch.setattr(
-        sys, "argv",
+        sys,
+        "argv",
         ["srf", "--config", str(yaml_with_mail), "--dry-run", "--no-mail"],
     )
     main.main()
@@ -241,6 +256,7 @@ def test_dry_run_and_no_mail_combined(yaml_with_mail, mock_azure, monkeypatch):
 # ---------------------------------------------------------------------------
 # Tests — SRF_MASTER_CLIENT_SECRET env var auth path
 # ---------------------------------------------------------------------------
+
 
 def test_env_var_auth_skips_keyvault(no_kv_yaml, mock_azure, monkeypatch):
     """When SRF_MASTER_CLIENT_SECRET is set, no KV bootstrap is needed."""
@@ -263,11 +279,15 @@ def test_no_auth_source_uses_oidc_fallback(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr(sys, "argv", ["srf", "--config", str(p)])
 
     # Patch DefaultAzureCredential to prevent real network calls
-    with patch("srf.auth.provider.DefaultAzureCredential") as mock_dac, \
-         patch("srf.graph.client.GraphClient.__init__", lambda self, *a, **kw: None), \
-         patch("srf.graph.client.GraphClient.list_password_credentials",
-               lambda self, app_id: (_ for _ in ()).throw(RuntimeError("no token"))), \
-         patch("srf.graph.client.GraphClient.list_owners", lambda self, app_id: []):
+    with (
+        patch("srf.auth.provider.DefaultAzureCredential") as mock_dac,
+        patch("srf.graph.client.GraphClient.__init__", lambda self, *a, **kw: None),
+        patch(
+            "srf.graph.client.GraphClient.list_password_credentials",
+            lambda self, app_id: (_ for _ in ()).throw(RuntimeError("no token")),
+        ),
+        patch("srf.graph.client.GraphClient.list_owners", lambda self, app_id: []),
+    ):
         mock_dac.return_value = MagicMock()
         result = main.main()
 

--- a/tests/test_keyvault_client.py
+++ b/tests/test_keyvault_client.py
@@ -1,4 +1,5 @@
 """Tests for KeyVaultClient and parse_keyvault_uri."""
+
 from __future__ import annotations
 
 import pytest
@@ -9,6 +10,7 @@ from srf.keyvault.client import KeyVaultClient, parse_keyvault_uri
 # ---------------------------------------------------------------------------
 # parse_keyvault_uri
 # ---------------------------------------------------------------------------
+
 
 def test_parse_keyvault_uri_standard():
     rid = "/subscriptions/sub-id/resourceGroups/my-rg/providers/Microsoft.KeyVault/vaults/my-vault"
@@ -29,7 +31,9 @@ def test_parse_keyvault_uri_invalid_raises():
 # KeyVaultClient
 # ---------------------------------------------------------------------------
 
-KV_ID = "/subscriptions/s/resourceGroups/r/providers/Microsoft.KeyVault/vaults/test-vault"
+KV_ID = (
+    "/subscriptions/s/resourceGroups/r/providers/Microsoft.KeyVault/vaults/test-vault"
+)
 
 
 def test_get_secret(monkeypatch):
@@ -57,10 +61,11 @@ def test_set_secret_without_description(monkeypatch):
         def __init__(self, vault_url, credential):
             pass
 
-        def set_secret(self, name, value, content_type=None):
+        def set_secret(self, name, value, content_type=None, expires_on=None):
             calls["name"] = name
             calls["value"] = value
             calls["content_type"] = content_type
+            calls["expires_on"] = expires_on
 
     monkeypatch.setattr("srf.keyvault.client.SecretClient", FakeSecretClient)
     client = KeyVaultClient(credential=object(), keyvault_id=KV_ID)
@@ -69,6 +74,7 @@ def test_set_secret_without_description(monkeypatch):
     assert calls["name"] == "my-key"
     assert calls["value"] == "my-value"
     assert calls["content_type"] is None
+    assert calls["expires_on"] is None
 
 
 def test_set_secret_with_description(monkeypatch):
@@ -78,8 +84,9 @@ def test_set_secret_with_description(monkeypatch):
         def __init__(self, vault_url, credential):
             pass
 
-        def set_secret(self, name, value, content_type=None):
+        def set_secret(self, name, value, content_type=None, expires_on=None):
             calls["content_type"] = content_type
+            calls["expires_on"] = expires_on
 
     monkeypatch.setattr("srf.keyvault.client.SecretClient", FakeSecretClient)
     client = KeyVaultClient(credential=object(), keyvault_id=KV_ID)

--- a/tests/test_ownership.py
+++ b/tests/test_ownership.py
@@ -1,4 +1,5 @@
 """Tests for OwnershipChecker."""
+
 from __future__ import annotations
 
 from unittest.mock import MagicMock
@@ -16,7 +17,7 @@ def _cfg(required_owners=None):
         name="test-sp",
         app_id="app-id",
         keyvault_id=KV_ID,
-        keyvault_secret_name="test-secret",
+        secret_name="test-secret",
         required_owners=required_owners or [],
     )
 
@@ -133,6 +134,7 @@ def test_skip_when_both_empty():
 # ---------------------------------------------------------------------------
 # dry-run
 # ---------------------------------------------------------------------------
+
 
 def test_dry_run_does_not_call_add_owner():
     graph = MagicMock(spec=GraphClient)

--- a/tests/test_rotator.py
+++ b/tests/test_rotator.py
@@ -249,7 +249,8 @@ def test_rotate_performs_rotation():
     kv.set_secret.assert_called_once_with(
         name="sp1-secret",
         value="new-secret-value",
-        description="desc",
+        description="desc - None",
+        expires_on=new_cred.end_date_time,
     )
     graph.remove_password_credential.assert_called_once_with(
         app_id="app-0001",

--- a/tests/test_rotator.py
+++ b/tests/test_rotator.py
@@ -1,4 +1,5 @@
 """Tests for SecretRotator — expiry logic and rotation flow."""
+
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
@@ -27,7 +28,7 @@ def _make_secret_cfg(description=None) -> SecretConfig:
         name="sp1",
         app_id="app-0001",
         keyvault_id=KV_ID,
-        keyvault_secret_name="sp1-secret",
+        secret_name="sp1-secret",
         keyvault_secret_description=description,
     )
 
@@ -43,14 +44,18 @@ def _make_rotator(graph, kv):
 # needs_rotation
 # ---------------------------------------------------------------------------
 
-@pytest.mark.parametrize("days,expected", [
-    (-1, True),   # already expired
-    (0, True),    # expires today
-    (6, True),    # within 7-day threshold
-    (7, True),    # exactly at threshold boundary (<=)
-    (8, False),   # just outside threshold
-    (30, False),  # well in the future
-])
+
+@pytest.mark.parametrize(
+    "days,expected",
+    [
+        (-1, True),  # already expired
+        (0, True),  # expires today
+        (6, True),  # within 7-day threshold
+        (7, True),  # exactly at threshold boundary (<=)
+        (8, False),  # just outside threshold
+        (30, False),  # well in the future
+    ],
+)
 def test_needs_rotation_threshold(days, expected):
     graph = MagicMock()
     kv = MagicMock()
@@ -118,7 +123,7 @@ def test_rotate_forced_when_per_secret_threshold_is_zero():
         name="sp1",
         app_id="app-0001",
         keyvault_id=KV_ID,
-        keyvault_secret_name="sp1-secret",
+        secret_name="sp1-secret",
         threshold_days=0,
         validity_days=90,
     )
@@ -152,7 +157,6 @@ def test_rotate_forced_when_global_threshold_is_zero():
 
     assert result.rotated is True
     kv.set_secret.assert_called_once()
-
 
 
 def test_rotate_skipped_when_not_expiring():
@@ -219,6 +223,7 @@ def test_dry_run_reports_kv_secret_missing():
 # rotate — rotation performed
 # ---------------------------------------------------------------------------
 
+
 def test_rotate_performs_rotation():
     new_key_id = "key-new"
     new_cred = MagicMock()
@@ -270,7 +275,9 @@ def test_rotate_new_cred_not_removed():
     rotator.rotate(_make_secret_cfg())
 
     # remove should only be called for the OLD key
-    call_args = [c.kwargs["key_id"] for c in graph.remove_password_credential.call_args_list]
+    call_args = [
+        c.kwargs["key_id"] for c in graph.remove_password_credential.call_args_list
+    ]
     assert "key-new" not in call_args
     assert "key-old" in call_args
 
@@ -278,6 +285,7 @@ def test_rotate_new_cred_not_removed():
 # ---------------------------------------------------------------------------
 # rotate — error handling
 # ---------------------------------------------------------------------------
+
 
 def test_rotate_returns_error_result_on_graph_failure():
     graph = MagicMock()
@@ -335,6 +343,7 @@ def test_rotate_cleanup_failure_recorded_as_warning():
     assert len(result.cleanup_warnings) == 1
     assert "k-old" in result.cleanup_warnings[0]
     assert "RuntimeError" in result.cleanup_warnings[0]
+
 
 def _make_dry_rotator(graph, kv):
     return SecretRotator(
@@ -423,6 +432,7 @@ def test_dry_run_was_created_true_no_prior_creds():
 # per-secret threshold_days / validity_days overrides
 # ---------------------------------------------------------------------------
 
+
 def test_per_secret_threshold_triggers_earlier_rotation():
     """Secret with threshold_days=20 should rotate a cred expiring in 15 days."""
     new_cred = MagicMock()
@@ -431,13 +441,18 @@ def test_per_secret_threshold_triggers_earlier_rotation():
     new_cred.end_date_time = NOW + timedelta(days=365)
 
     graph = MagicMock()
-    graph.list_password_credentials.return_value = [_cred(15)]  # outside global 7-day threshold
+    graph.list_password_credentials.return_value = [
+        _cred(15)
+    ]  # outside global 7-day threshold
     graph.add_password_credential.return_value = new_cred
 
     rotator = _make_rotator(graph, MagicMock())
     cfg = SecretConfig(
-        name="sp1", app_id="app-0001", keyvault_id=KV_ID,
-        keyvault_secret_name="sp1-secret", threshold_days=20,
+        name="sp1",
+        app_id="app-0001",
+        keyvault_id=KV_ID,
+        secret_name="sp1-secret",
+        threshold_days=20,
     )
 
     result = rotator.rotate(cfg)
@@ -447,12 +462,17 @@ def test_per_secret_threshold_triggers_earlier_rotation():
 def test_per_secret_threshold_suppresses_rotation():
     """Secret with threshold_days=3 should skip a cred expiring in 5 days (global=7 would rotate)."""
     graph = MagicMock()
-    graph.list_password_credentials.return_value = [_cred(5)]  # within global 7-day threshold
+    graph.list_password_credentials.return_value = [
+        _cred(5)
+    ]  # within global 7-day threshold
 
     rotator = _make_rotator(graph, MagicMock())
     cfg = SecretConfig(
-        name="sp1", app_id="app-0001", keyvault_id=KV_ID,
-        keyvault_secret_name="sp1-secret", threshold_days=3,
+        name="sp1",
+        app_id="app-0001",
+        keyvault_id=KV_ID,
+        secret_name="sp1-secret",
+        threshold_days=3,
     )
 
     result = rotator.rotate(cfg)
@@ -473,14 +493,17 @@ def test_per_secret_validity_days_used_in_add_credential():
 
     rotator = _make_rotator(graph, MagicMock())
     cfg = SecretConfig(
-        name="sp1", app_id="app-0001", keyvault_id=KV_ID,
-        keyvault_secret_name="sp1-secret", validity_days=180,
+        name="sp1",
+        app_id="app-0001",
+        keyvault_id=KV_ID,
+        secret_name="sp1-secret",
+        validity_days=180,
     )
 
     rotator.rotate(cfg)
     graph.add_password_credential.assert_called_once_with(
         app_id="app-0001",
-        display_name="rotated-by-srf",
+        display_name="Default Secret",
         validity_days=180,
     )
 
@@ -489,9 +512,12 @@ def test_per_secret_validity_validator_rejects_invalid():
     """validity_days <= threshold_days on the same secret must raise."""
     with pytest.raises(Exception, match="validity_days"):
         SecretConfig(
-            name="sp1", app_id="app-0001", keyvault_id=KV_ID,
-            keyvault_secret_name="sp1-secret",
-            threshold_days=30, validity_days=30,
+            name="sp1",
+            app_id="app-0001",
+            keyvault_id=KV_ID,
+            secret_name="sp1-secret",
+            threshold_days=30,
+            validity_days=30,
         )
 
 
@@ -512,13 +538,16 @@ def test_per_secret_only_threshold_no_validity_uses_global_validity():
         validity_days=180,
     )
     cfg = SecretConfig(
-        name="sp1", app_id="app-0001", keyvault_id=KV_ID,
-        keyvault_secret_name="sp1-secret", threshold_days=14,
+        name="sp1",
+        app_id="app-0001",
+        keyvault_id=KV_ID,
+        secret_name="sp1-secret",
+        threshold_days=14,
     )
 
     rotator.rotate(cfg)
     graph.add_password_credential.assert_called_once_with(
         app_id="app-0001",
-        display_name="rotated-by-srf",
+        display_name="Default Secret",
         validity_days=180,
     )

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,4 +1,5 @@
 """Tests for ParallelRunner — concurrency and error isolation."""
+
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
@@ -19,12 +20,17 @@ def _cfg(name, app_id):
         name=name,
         app_id=app_id,
         keyvault_id=KV_ID,
-        keyvault_secret_name=f"{name}-secret",
+        secret_name=f"{name}-secret",
     )
 
 
 def _ok_result(cfg: SecretConfig) -> RotationResult:
-    return RotationResult(name=cfg.name, app_id=cfg.app_id, rotated=True, new_expiry=NOW + timedelta(days=365))
+    return RotationResult(
+        name=cfg.name,
+        app_id=cfg.app_id,
+        rotated=True,
+        new_expiry=NOW + timedelta(days=365),
+    )
 
 
 def test_runner_returns_all_results():
@@ -71,6 +77,7 @@ def test_runner_continues_after_one_failure():
 def test_runner_respects_max_workers(monkeypatch):
     """Verify ThreadPoolExecutor is initialised with the configured max_workers."""
     import concurrent.futures as cf
+
     captured = {}
 
     original_init = cf.ThreadPoolExecutor.__init__
@@ -113,7 +120,9 @@ def test_runner_ownership_results():
         OwnershipResult(name="sp2", app_id="a2", checked=False),
     ]
 
-    runner = ParallelRunner(rotator=rotator, ownership_checker=ownership_checker, max_workers=2)
+    runner = ParallelRunner(
+        rotator=rotator, ownership_checker=ownership_checker, max_workers=2
+    )
     rotation_results, ownership_results = runner.run(secrets)
 
     assert len(rotation_results) == 2
@@ -121,4 +130,3 @@ def test_runner_ownership_results():
     assert all(r.rotated for r in rotation_results)
     ownership_names = {r.name for r in ownership_results}
     assert ownership_names == {"sp1", "sp2"}
-


### PR DESCRIPTION
## Summary

Two fixes in this PR:

### 1. `fix(rotation)`: Store `run_id` on `SecretRotator` and forward to Key Vault

- Store `run_id` as `self._run_id` so it is accessible beyond `__init__`
- Append `run_id` to the KV secret `content_type` (description) for traceability — each rotated secret in Key Vault now references the exact run that created it
- Pass `expires_on` to `KeyVaultClient.set_secret` so the KV secret TTL mirrors the Azure AD credential expiry
- Use full `run_id` string in `display_name` (previously truncated to 13 chars)
- Add `expires_on: datetime | None` parameter to `KeyVaultClient.set_secret`

### 2. `fix(run_id)`: `decode()` returns `"cli"` event for CLI origin runs

**Bug:** When decoding a CLI run ID (e.g. via `main.py decode <uuid>`), `event` showed `"schedule"` instead of `"cli"`.

**Root cause:** CLI runs always encode `event_code=0` (from `_detect_context` returning `0, 0, 0`), and `event_code=0` maps to `"schedule"` in `_EVENT_NAMES`. The `RunIdService.event` *property* masked this by returning `"cli"` when `origin == "cli"`, but `decode()` called directly returned the raw misleading value.

**Fix:** `decode()` now sets `event = "cli"` when `origin_bit == 0`, making `RunIdInfo` semantically correct regardless of how it is consumed.