### PR TITLE
feat: add cleanup_old_secrets flag to MainConfig (default false)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -99,6 +99,7 @@ tests/
 - One feature/fix per PR; all CI checks must be green before merging.
 - Target branch: `master`
 - Don't add copilot as Co-Author in commit messages — the commit history should reflect human authorship only.
+- **Before starting any new feature or fix, always create a dedicated branch** (`git checkout -b feature/<desc>`) and verify you are on that branch before making any commits.
 
 ---
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -100,6 +100,7 @@ tests/
 - Target branch: `master`
 - Don't add copilot as Co-Author in commit messages — the commit history should reflect human authorship only.
 - **Before starting any new feature or fix, always create a dedicated branch** (`git checkout -b feature/<desc>`) and verify you are on that branch before making any commits.
+- **When using `/fleet` or any command that implies parallel development across multiple features, use git worktrees** instead of switching branches in the same working directory. Create a worktree per feature: `git worktree add ../SRF-<desc> feature/<desc>`. This keeps each feature's working tree isolated and avoids accidental cross-feature commits.
 
 ---
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -111,6 +111,11 @@
           },
           "title": "Master Owners",
           "type": "array"
+        },
+        "cleanup_old_secrets": {
+          "default": false,
+          "title": "Cleanup Old Secrets",
+          "type": "boolean"
         }
       },
       "required": [

--- a/input.yaml
+++ b/input.yaml
@@ -15,6 +15,7 @@ main:
   # master_secret_name: master-sp-client-secret
   threshold_days: 7
   validity_days: 365
+  # cleanup_old_secrets: false  # Set to true to delete old SP credentials after rotation
   master_owners: # user object ID added to every SP
     - 1338bb98-3041-4ef6-840d-45454bf9945f
     - 4a0773b4-bddf-47e2-b1fd-8c847f9a6319   

--- a/main.py
+++ b/main.py
@@ -383,6 +383,7 @@ def main() -> int:
         validity_days=validity,
         dry_run=args.dry_run,
         run_id=run_id_svc.run_id,
+        cleanup_old_secrets=config.main.cleanup_old_secrets,
     )
     ownership_checker = OwnershipChecker(
         graph_client=graph,

--- a/srf/config/models.py
+++ b/srf/config/models.py
@@ -16,6 +16,7 @@ class MainConfig(BaseModel):
     threshold_days: int = Field(default=7, ge=0, le=365)
     validity_days: ValidityDays = Field(default=365)
     master_owners: list[str] = Field(default_factory=list)
+    cleanup_old_secrets: bool = Field(default=False)
 
     @model_validator(mode="after")
     def _validity_exceeds_threshold(self) -> "MainConfig":

--- a/srf/rotation/rotator.py
+++ b/srf/rotation/rotator.py
@@ -46,6 +46,7 @@ class SecretRotator:
         validity_days: int = 365,
         dry_run: bool = False,
         run_id: Optional[str] = None,
+        cleanup_old_secrets: bool = False,
     ) -> None:
         """
         Args:
@@ -58,12 +59,15 @@ class SecretRotator:
             run_id: UUID v8 run identifier used as the Azure AD credential display_name
                 prefix (``{secret_name}-<first_13_chars>``). When omitted, falls back to the
                 static string ``"{secret_name}"``.
+            cleanup_old_secrets: If True, remove all previous SP credentials after a
+                successful rotation. Defaults to False (old credentials are retained).
         """
         self._graph = graph_client
         self._kv_factory = keyvault_client_factory
         self._threshold = timedelta(days=threshold_days)
         self._validity_days = validity_days
         self._dry_run = dry_run
+        self._cleanup_old_secrets = cleanup_old_secrets
         self._display_name = f"{secret_name}-{run_id}" if run_id else secret_name
         self._run_id = run_id
 
@@ -236,29 +240,35 @@ class SecretRotator:
             )
 
             cleanup_warnings: list[str] = []
-            for old_cred in credentials:
-                if old_cred.key_id and old_cred.key_id != new_cred.key_id:
-                    logger.debug(
-                        "[%s] removing old credential key_id=%s",
-                        secret_config.name,
-                        old_cred.key_id,
-                    )
-                    try:
-                        self._graph.remove_password_credential(
-                            app_id=secret_config.app_id,
-                            key_id=str(old_cred.key_id),
-                        )
-                    except Exception as exc:
-                        cleanup_warnings.append(
-                            f"Failed to remove old credential {old_cred.key_id}: "
-                            f"{type(exc).__name__}"
-                        )
-                        logger.warning(
-                            "[%s] cleanup failed for key_id=%s: %s",
+            if self._cleanup_old_secrets:
+                for old_cred in credentials:
+                    if old_cred.key_id and old_cred.key_id != new_cred.key_id:
+                        logger.debug(
+                            "[%s] removing old credential key_id=%s",
                             secret_config.name,
                             old_cred.key_id,
-                            type(exc).__name__,
                         )
+                        try:
+                            self._graph.remove_password_credential(
+                                app_id=secret_config.app_id,
+                                key_id=str(old_cred.key_id),
+                            )
+                        except Exception as exc:
+                            cleanup_warnings.append(
+                                f"Failed to remove old credential {old_cred.key_id}: "
+                                f"{type(exc).__name__}"
+                            )
+                            logger.warning(
+                                "[%s] cleanup failed for key_id=%s: %s",
+                                secret_config.name,
+                                old_cred.key_id,
+                                type(exc).__name__,
+                            )
+            else:
+                logger.debug(
+                    "[%s] skipping old credential cleanup (cleanup_old_secrets disabled)",
+                    secret_config.name,
+                )
 
             logger.info(
                 "[%s] rotation complete new_expiry=%s",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -269,3 +269,31 @@ def test_per_secret_validity_must_exceed_threshold(tmp_path):
 
     with pytest.raises(Exception, match="validity_days"):
         load_config(str(cfg_file))
+
+
+def test_cleanup_old_secrets_default_false(tmp_path):
+    cfg_file = tmp_path / "cfg.yaml"
+    cfg_file.write_text(MINIMAL_YAML)
+
+    cfg = load_config(str(cfg_file))
+
+    assert cfg.main.cleanup_old_secrets is False
+
+
+def test_cleanup_old_secrets_can_be_enabled(tmp_path):
+    yaml_text = textwrap.dedent("""\
+        main:
+          tenant_id: tid
+          cleanup_old_secrets: true
+        secrets:
+          - name: sp1
+            app_id: app-001
+            keyvault_id: /subscriptions/s/resourceGroups/r/providers/Microsoft.KeyVault/vaults/sp-kv
+            secret_name: sp1-secret
+    """)
+    cfg_file = tmp_path / "cfg.yaml"
+    cfg_file.write_text(yaml_text)
+
+    cfg = load_config(str(cfg_file))
+
+    assert cfg.main.cleanup_old_secrets is True

--- a/tests/test_rotator.py
+++ b/tests/test_rotator.py
@@ -238,7 +238,11 @@ def test_rotate_performs_rotation():
     graph.add_password_credential.return_value = new_cred
 
     kv = MagicMock()
-    rotator = _make_rotator(graph, kv)
+    rotator = SecretRotator(
+        graph_client=graph,
+        keyvault_client_factory=lambda _: kv,
+        cleanup_old_secrets=True,
+    )
     result = rotator.rotate(_make_secret_cfg(description="desc"))
 
     assert result.rotated is True
@@ -272,7 +276,11 @@ def test_rotate_new_cred_not_removed():
     graph.list_password_credentials.return_value = [old_cred]
     graph.add_password_credential.return_value = new_cred
 
-    rotator = _make_rotator(graph, MagicMock())
+    rotator = SecretRotator(
+        graph_client=graph,
+        keyvault_client_factory=lambda _: MagicMock(),
+        cleanup_old_secrets=True,
+    )
     rotator.rotate(_make_secret_cfg())
 
     # remove should only be called for the OLD key
@@ -336,7 +344,11 @@ def test_rotate_cleanup_failure_recorded_as_warning():
     graph.add_password_credential.return_value = new_cred
     graph.remove_password_credential.side_effect = RuntimeError("Graph error")
 
-    rotator = _make_rotator(graph, MagicMock())
+    rotator = SecretRotator(
+        graph_client=graph,
+        keyvault_client_factory=lambda _: MagicMock(),
+        cleanup_old_secrets=True,
+    )
     result = rotator.rotate(_make_secret_cfg())
 
     assert result.rotated is True
@@ -551,4 +563,59 @@ def test_per_secret_only_threshold_no_validity_uses_global_validity():
         app_id="app-0001",
         display_name="Default Secret",
         validity_days=180,
+    )
+
+
+# ---------------------------------------------------------------------------
+# cleanup_old_secrets flag
+# ---------------------------------------------------------------------------
+
+
+def test_cleanup_disabled_by_default_no_remove_called():
+    """With cleanup_old_secrets=False (default), old credentials are not deleted."""
+    new_cred = MagicMock()
+    new_cred.key_id = "key-new"
+    new_cred.secret_text = "s"
+    new_cred.end_date_time = NOW + timedelta(days=365)
+
+    old_cred = _cred(-5)
+    old_cred.key_id = "key-old"
+
+    graph = MagicMock()
+    graph.list_password_credentials.return_value = [old_cred]
+    graph.add_password_credential.return_value = new_cred
+
+    rotator = _make_rotator(graph, MagicMock())  # cleanup_old_secrets defaults to False
+    result = rotator.rotate(_make_secret_cfg())
+
+    assert result.rotated is True
+    assert result.cleanup_warnings == []
+    graph.remove_password_credential.assert_not_called()
+
+
+def test_cleanup_enabled_removes_old_credentials():
+    """With cleanup_old_secrets=True, old credentials are deleted after rotation."""
+    new_cred = MagicMock()
+    new_cred.key_id = "key-new"
+    new_cred.secret_text = "s"
+    new_cred.end_date_time = NOW + timedelta(days=365)
+
+    old_cred = _cred(-5)
+    old_cred.key_id = "key-old"
+
+    graph = MagicMock()
+    graph.list_password_credentials.return_value = [old_cred]
+    graph.add_password_credential.return_value = new_cred
+
+    rotator = SecretRotator(
+        graph_client=graph,
+        keyvault_client_factory=lambda _: MagicMock(),
+        cleanup_old_secrets=True,
+    )
+    result = rotator.rotate(_make_secret_cfg())
+
+    assert result.rotated is True
+    graph.remove_password_credential.assert_called_once_with(
+        app_id="app-0001",
+        key_id="key-old",
     )


### PR DESCRIPTION
## Summary

Adds a `cleanup_old_secrets` boolean flag to `MainConfig` (default `false`) that controls whether old SP credentials are deleted from Azure AD after a successful rotation.

## Changes

- **`srf/config/models.py`** — new `cleanup_old_secrets: bool = Field(default=False)` field on `MainConfig`
- **`srf/rotation/rotator.py`** — new `cleanup_old_secrets` param on `SecretRotator.__init__`; cleanup loop is gated behind the flag; logs a debug message when skipped
- **`main.py`** — passes `config.main.cleanup_old_secrets` to the rotator
- **`config.schema.json`** — updated so `--validate` accepts the new field
- **`input.yaml`** — added commented example
- **`tests/test_config.py`** — 2 new tests (default false, can be enabled)
- **`tests/test_rotator.py`** — 3 existing cleanup tests updated to use `cleanup_old_secrets=True` explicitly; 2 new tests

## Behaviour

| `cleanup_old_secrets` | Result |
|---|---|
| `false` (default) | Old SP credentials are retained after rotation |
| `true` | Old SP credentials are deleted; failures recorded as `cleanup_warnings` |
