### PR TITLE
chore(ci): cache Poetry virtualenv in OIDC workflow

### DIFF
--- a/.github/workflows/srf-run-oidc.yml
+++ b/.github/workflows/srf-run-oidc.yml
@@ -64,9 +64,16 @@ jobs:
           version: "2.3.4"
           virtualenvs-in-project: true
 
+      - name: Cache Poetry virtualenv
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
+          restore-keys: |
+            venv-${{ runner.os }}-${{ matrix.python-version }}-
+
       - name: Install dependencies
         run: poetry install --no-interaction
-
 
       - name: Validate config
         run: poetry run python main.py --config input.yaml --validate


### PR DESCRIPTION
## Summary

Adds a `actions/cache@v4` step to the OIDC workflow to cache the Poetry `.venv` directory, keyed by OS, Python version and `poetry.lock` hash.

## Changes

- Cache key: `venv-{os}-{python-version}-{poetry.lock hash}`
- Restore key fallback for partial cache hits on Python version
- Removes stray blank line after `Install dependencies` step

## Effect

Subsequent runs with an unchanged `poetry.lock` skip dependency installation entirely, reducing CI time.
